### PR TITLE
Update 50.v61.mc.csv

### DIFF
--- a/ebusd-2.1.x/de/vaillant/50.v61.mc.csv
+++ b/ebusd-2.1.x/de/vaillant/50.v61.mc.csv
@@ -66,6 +66,7 @@ r,,OffConfig,OffConfig,,,,"4E00",,,UCH,,,"0 = _OffConfig_Off, 1 = _OffConfig_Low
 r,,FrostProtConfig,FrostProtConfig,,,,"4F00",,,UCH,,,"0 = _FrostProtConfig_Low, 1 = _FrostProtConfig_PumpKick"
 r,,FrostProtState,FrostProtState,,,,"4B00",,,UCH,,,"0 = _Fps_NoFrost, 1 = _Fps_Delay, 2 = _Fps_PumpKick, 3 = _Fps_KickOff, 4 = _Fps_Active"
 r,,ThermostatState,ThermostatState,,,,"5100",,,UCH,,,"0 = _ThermOn, 1 =_ThermOff"
+w,,Hc2WriteDayTemp,Tagtemperatur setzen,,,”B505","42",,,temp1,,,,,,
 !include,errors.inc,,,,,,,,,,,,
 !include,timerhc.inc,,,,,,,,,,,,
 !include,tempsetpoints.inc,,,,,,,,,,,,


### PR DESCRIPTION
Hi, not sure about this change: Tried to set the daytemp of the second heat circuit with the commands in tempsetpoints. However the v61 wrote the wrong info into the registers. 

e.g. i wrote 
w -c mc Setpoints.Monday 0.5;20;20
 .. the result was: 0.5;0.5;0.5 instead of 0.5;20;20

I traced the communication of 470 and V61. If I set the daytemp for HC2 at the 470 manually .. it sends 10 50b50502422a / 00 to the v61. then all days are set to x.x;21.0;21.0

The command ”B505","42",,,temp1 works fine for writing ...