### PR TITLE
Corrected name of "C700"

### DIFF
--- a/ebusd-2.1.x/de/vaillant/bai.0010010674.inc
+++ b/ebusd-2.1.x/de/vaillant/bai.0010010674.inc
@@ -95,7 +95,7 @@ r,,SHEMaxFlowTemp,Max. WW Vorlauftemp.,,,,"C300",,,temp,,,Max. Vorlauftemperatur
 r,,SHEMaxDeltaHwcFlow,SHE_MaxDeltaFlowDHW_DK,,,,"C400",,,temp,,,maximum difference between flow and DHW outlet temperature
 r,,PrEnergySumHwc1,PrEnergySumDHW1_DK,,,,"C500",,,ULG,,,Wartungsdaten
 r,,PrEnergyCountHwc1,PrEnergyCountDHW1_DK,,,,"C600",,,ULG,,,Wartungsdaten
-r,,maintenancedata_PrEnergySumHwc1,PrEnergySumDHW1_DK,,,,"C700",,,ULG,,,Wartungsdaten
+r,,PrEnergySumHwc2,PrEnergySumDHW2_DK,,,,"C700",,,ULG,,,Wartungsdaten
 r,,PrEnergyCountHwc2,PrEnergyCountDHW2_DK,,,,"C800",,,ULG,,,Wartungsdaten
 r,,PrEnergySumHwc3,PrEnergySumDHW3_DK,,,,"C900",,,ULG,,,Wartungsdaten
 r,,PrEnergyCountHwc3,PrEnergyCountDHW3_DK,,,,"CA00",,,ULG,,,Wartungsdaten

--- a/ebusd-2.1.x/en/vaillant/bai.0010010674.inc
+++ b/ebusd-2.1.x/en/vaillant/bai.0010010674.inc
@@ -95,7 +95,7 @@ r,,SHEMaxFlowTemp,SHE_MaxFlowTemp_DK,,,,"C300",,,temp,,,maximum flow temperature
 r,,SHEMaxDeltaHwcFlow,SHE_MaxDeltaFlowDHW_DK,,,,"C400",,,temp,,,maximum difference between flow and DHW outlet temperature
 r,,PrEnergySumHwc1,PrEnergySumDHW1_DK,,,,"C500",,,ULG,,,Predictive Maintenance data
 r,,PrEnergyCountHwc1,PrEnergyCountDHW1_DK,,,,"C600",,,ULG,,,Predictive Maintenance data
-r,,maintenancedata_PrEnergySumHwc1,PrEnergySumDHW1_DK,,,,"C700",,,ULG,,,Predictive Maintenance data
+r,,PrEnergySumHwc2,PrEnergySumDHW2_DK,,,,"C700",,,ULG,,,Predictive Maintenance data
 r,,PrEnergyCountHwc2,PrEnergyCountDHW2_DK,,,,"C800",,,ULG,,,Predictive Maintenance data
 r,,PrEnergySumHwc3,PrEnergySumDHW3_DK,,,,"C900",,,ULG,,,Predictive Maintenance data
 r,,PrEnergyCountHwc3,PrEnergyCountDHW3_DK,,,,"CA00",,,ULG,,,Predictive Maintenance data


### PR DESCRIPTION
In this order it makes more sense to be PrEnergySumHwc2, as it is named in older 08.bai.HW7401.csv and current bai.308523.inc - or do I miss some relevant information?