### PR TITLE
Include hcmode for HMU

### DIFF
--- a/ebusd-2.1.x/de/vaillant/08.hmu.csv
+++ b/ebusd-2.1.x/de/vaillant/08.hmu.csv
@@ -41,5 +41,6 @@ r,,ConsumptionThisYear9,,,,,0900,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
 r,,ConsumptionThisYear10,,,,,0A00,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
 r,,ConsumptionThisYear11,,,,,0B00,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
 r,,ConsumptionThisYear12,,,,,0C00,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
+!include,hcmode.inc,,,,,,,,,,,,
 !include,errors.inc,,,,,,,,,,,,
 

--- a/ebusd-2.1.x/en/vaillant/08.hmu.csv
+++ b/ebusd-2.1.x/en/vaillant/08.hmu.csv
@@ -41,5 +41,6 @@ r,,ConsumptionThisYear9,,,,,0900,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
 r,,ConsumptionThisYear10,,,,,0A00,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
 r,,ConsumptionThisYear11,,,,,0B00,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
 r,,ConsumptionThisYear12,,,,,0C00,month,,D1B,,,,,,IGN:1,,,,,,energy,,,
+!include,hcmode.inc,,,,,,,,,,,,
 !include,errors.inc,,,,,,,,,,,,
 


### PR DESCRIPTION
Minimum support for HMU device was already implemented, but leaves a lot of "unknown MS cmd" messages in log file.
It's not complete at all, but reduces at least the unknown issues for many commonly requested messages from VRCxxx control units.