### PR TITLE
vaillant/_templates: add pumpstate=4 (warming the hot water circuit)

### DIFF
--- a/ebusd-2.1.x/de/vaillant/_templates.csv
+++ b/ebusd-2.1.x/de/vaillant/_templates.csv
@@ -75,7 +75,7 @@ energy4,ULG,,kWh,
 cntstarts,ULG,,,Anzahl Starts
 cntstarts2,UIN,,,Anzahl Starts
 pumppow,UCH,0=0;1=1;2=2;3=3;4=4;5=5;6=6;7=off,,Pumpenleistung
-pumpstate,UCH,0=off;1=on;2=overrun,,Pumpenstatus
+pumpstate,UCH,0=off;1=on;2=overrun;4=hwc,,Pumpenstatus
 dcfstate,UCH,0=nosignal;1=ok;2=sync;3=valid,,DCF Empfängerstatus
 phaseok,UCH,0=error;7=ok,,Phasenstatus
 switchvalve,UCH,0=heat;1=water,,Ventilposition

--- a/ebusd-2.1.x/en/vaillant/_templates.csv
+++ b/ebusd-2.1.x/en/vaillant/_templates.csv
@@ -75,7 +75,7 @@ energy4,ULG,,kWh,
 cntstarts,ULG,,,start count
 cntstarts2,UIN,,,start count
 pumppow,UCH,0=0;1=1;2=2;3=3;4=4;5=5;6=6;7=off,,pump power
-pumpstate,UCH,0=off;1=on;2=overrun,,pump state
+pumpstate,UCH,0=off;1=on;2=overrun;4=hwc,,pump state
 dcfstate,UCH,0=nosignal;1=ok;2=sync;3=valid,,DCF receiver state
 phaseok,UCH,0=error;7=ok,,phase state
 switchvalve,UCH,0=heat;1=water,,valve position


### PR DESCRIPTION
This diff adds a new `pumpstate`. State `4` has been observed on Protherm heaters with hot water circuit connected, while the heater warms up the water in the boiler. As soon as the water is warmed up, the heater switches to either state `0` (off) or `1` (warming up the home heating circuit).