### PR TITLE
CSV format fix of vrc700 template

### DIFF
--- a/ebusd-2.1.x/de/vaillant/15.700.csv
+++ b/ebusd-2.1.x/de/vaillant/15.700.csv
@@ -294,5 +294,5 @@ r;w,,z2CoolingTimer.Thursday,Zeitfenster Kühlen Donnerstag,,,,03,,,slot1-3,,,
 r;w,,z2CoolingTimer.Friday,Zeitfenster Kühlen Freitag,,,,04,,,slot1-3,,,
 r;w,,z2CoolingTimer.Saturday,Zeitfenster Kühlen Samstag,,,,05,,,slot1-3,,,
 r;w,,z2CoolingTimer.Sunday,Zeitfenster Kühlen Sonntag,,,,06,,,slot1-3,,,
-# includes
+# includes,,,,,,,,,,,,,
 !include,errors.inc,,,,,,,,,,,,

--- a/ebusd-2.1.x/en/vaillant/15.700.csv
+++ b/ebusd-2.1.x/en/vaillant/15.700.csv
@@ -294,5 +294,5 @@ r;w,,z2CoolingTimer.Thursday,timer cooling thursday,,,,03,,,slot1-3,,,
 r;w,,z2CoolingTimer.Friday,timer cooling friday,,,,04,,,slot1-3,,,
 r;w,,z2CoolingTimer.Saturday,timer cooling saturday,,,,05,,,slot1-3,,,
 r;w,,z2CoolingTimer.Sunday,timer cooling sunday,,,,06,,,slot1-3,,,
-# includes
+# includes,,,,,,,,,,,,,
 !include,errors.inc,,,,,,,,,,,,


### PR DESCRIPTION
This is only a small fix for the CSV format issue in the VRC700 CSV file. Due to missing columns in the last comment row, the file was not displayed properly in e.g. GitHub.

### Before:
![image](https://user-images.githubusercontent.com/1692044/137787918-9d5f676b-ea00-4d7a-8359-3e122d1c619d.png)

### After fix:
![image](https://user-images.githubusercontent.com/1692044/137788056-dfb24710-95f7-4f56-b7f7-08509d40848d.png)
