### PR TITLE
make energy counters resettable for vkk 226/4

### DIFF
--- a/ebusd-2.1.x/de/vaillant/bai.0010007508.inc
+++ b/ebusd-2.1.x/de/vaillant/bai.0010007508.inc
@@ -93,21 +93,21 @@ r,,PumpHwcFlowSum,PumpDHWFlowSum_DK,,,,"C100",,,UIN,,,summed up DHW flow rate
 r,,PumpHwcFlowNumber,PumpDHWFlowNumber_DK,,,,"C200",,,UCH,,,number of times DHW flow rate was detected
 r,,SHEMaxFlowTemp,Max. WW Vorlauftemp.,,,,"C300",,,temp,,,Max. Vorlauftemperatur für WW
 r,,SHEMaxDeltaHwcFlow,SHE_MaxDeltaFlowDHW_DK,,,,"C400",,,temp,,,maximum difference between flow and DHW outlet temperature
-r,,PrEnergySumHwc1,PrEnergySumDHW1_DK,,,,"C500",,,ULG,,,Wartungsdaten
-r,,PrEnergyCountHwc1,PrEnergyCountDHW1_DK,,,,"C600",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergySumHwc1,PrEnergySumDHW1_DK,,,,"C500",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergyCountHwc1,PrEnergyCountDHW1_DK,,,,"C600",,,ULG,,,Wartungsdaten
 r,,maintenancedata_PrEnergySumHwc1,PrEnergySumDHW1_DK,,,,"C700",,,ULG,,,Wartungsdaten
-r,,PrEnergyCountHwc2,PrEnergyCountDHW2_DK,,,,"C800",,,ULG,,,Wartungsdaten
-r,,PrEnergySumHwc3,PrEnergySumDHW3_DK,,,,"C900",,,ULG,,,Wartungsdaten
-r,,PrEnergyCountHwc3,PrEnergyCountDHW3_DK,,,,"CA00",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergyCountHwc2,PrEnergyCountDHW2_DK,,,,"C800",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergySumHwc3,PrEnergySumDHW3_DK,,,,"C900",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergyCountHwc3,PrEnergyCountDHW3_DK,,,,"CA00",,,ULG,,,Wartungsdaten
 r,,CurrentPartload,CurrentPartload,,,,"0001",,,UIN,,kW,Current calculated partload
 r,,WaterpressureVariantSum,WaterpressureVariantSum_DK,,,,"F000",,,pressm2,,,Wartungsdaten
 r,,WaterpressureMeasureCounter,WaterpressureMeasureCounter_DK,,,,"F100",,,UCH,,,Wartungsdaten
-r,,PrEnergySumHc1,PrEnergySumCH1_DK,,,,"F400",,,ULG,,,Wartungsdaten
-r,,PrEnergyCountHc1,PrEnergyCountCH1_DK,,,,"F500",,,ULG,,,Wartungsdaten
-r,,PrEnergySumHc2,PrEnergySumCH2_DK,,,,"F600",,,ULG,,,Wartungsdaten
-r,,PrEnergyCountHc2,PrEnergyCountCH2_DK,,,,"F700",,,ULG,,,Wartungsdaten
-r,,PrEnergySumHc3,PrEnergySumCH3_DK,,,,"F800",,,ULG,,,Wartungsdaten
-r,,PrEnergyCountHc3,PrEnergyCountCH3_DK,,,,"F900",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergySumHc1,PrEnergySumCH1_DK,,,,"F400",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergyCountHc1,PrEnergyCountCH1_DK,,,,"F500",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergySumHc2,PrEnergySumCH2_DK,,,,"F600",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergyCountHc2,PrEnergyCountCH2_DK,,,,"F700",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergySumHc3,PrEnergySumCH3_DK,,,,"F800",,,ULG,,,Wartungsdaten
+r;wi,,PrEnergyCountHc3,PrEnergyCountCH3_DK,,,,"F900",,,ULG,,,Wartungsdaten
 # ##### expert level\Main #####,,,,,,,,,,,,,
 r,,externalFlowTempDesired,ext. Vorlaufsollwert,,,,"2500",,,temp,,,Vorlaufsollwert von einem externen Regler an Klemme 7-8-9
 r,,externalHwcSwitch,Wasserschalter,,,,"0000",,,onoff,,,Speicheranforderung eines externen Speichers über den Speicherkontakt


### PR DESCRIPTION
As mentioned in this issue https://github.com/john30/ebusd-configuration/issues/117 there is a int32 overflow which prevents the bai from updating its energy counters/sums.

This PR makes those registers writeable.