### PR TITLE
Added ManualCooling and GlobalSystemOff to VRC-700

### DIFF
--- a/ebusd-2.1.x/de/vaillant/15.700.csv
+++ b/ebusd-2.1.x/de/vaillant/15.700.csv
@@ -3,6 +3,8 @@
 # ##### Generell #####,,,,,,,,,,,,,
 *r,,,,,,B524,02000000,,,IGN:4,,,
 *w,,,,,,B524,02010000,,,,,,
+r;w,,GlobalSystemOff,Global System Aus,,,,0700,,,onoff,,,Zum Ausschalten des Systems Wert auf TRUE (On) setzen
+r;w,,ManualCooling,Manuell kuehlen,,,,0600,,,UIN,,,"Anzahl der Tage manueller Kühlung. Maximale Tage = 99; 0 days = aus. Setze Temperatur via z1CoolingTemp."
 r;w,,ContinuosHeating,Durchgehendes Heizen,,,,0200,,,tempv,,,"-26=off, when the outside temperature falls below this threshold temperature the continuous heating function is started (off <=> function is disabled)"
 r;w,,FrostOverRideTime,Frostschutz-Verzögerung,,,,0300,,,hoursum2,,,delay before frost protection is activated
 r;w,,HwcParallelLoading,Parallele Ladung Warmwasserkreis,,,,0A00,,,onoff,,,Heizbetrieb und Speicherladung parallel

--- a/ebusd-2.1.x/en/vaillant/15.700.csv
+++ b/ebusd-2.1.x/en/vaillant/15.700.csv
@@ -3,6 +3,8 @@
 # ##### Generell #####,,,,,,,,,,,,,
 *r,,,,,,B524,02000000,,,IGN:4,,,
 *w,,,,,,B524,02010000,,,,,,
+r;w,,GlobalSystemOff,GlobalSystemOFF,,,,0700,,,onoff,,,Set to TRUE (On) if "System Off" is selected
+r;w,,ManualCooling,ManualCooling,,,,0600,,,UIN,,,"number of days of manual cooling. Max. days = 99. 0 days = off. Set temp via z1CoolingTemp."
 r;w,,ContinuosHeating,continuos heating,,,,0200,,,tempv,,,"-26=off, when the outside temperature falls below this threshold temperature the continuous heating function is started (off <=> function is disabled)"
 r;w,,FrostOverRideTime,frost delay time,,,,0300,,,hoursum2,,,delay before frost protection is activated
 r;w,,HwcParallelLoading,hwc parallel loading,,,,0A00,,,onoff,,,heating and hot water parallel

--- a/ebusd-2.1.x/en/vaillant/15.700.csv
+++ b/ebusd-2.1.x/en/vaillant/15.700.csv
@@ -3,7 +3,7 @@
 # ##### Generell #####,,,,,,,,,,,,,
 *r,,,,,,B524,02000000,,,IGN:4,,,
 *w,,,,,,B524,02010000,,,,,,
-r;w,,GlobalSystemOff,GlobalSystemOFF,,,,0700,,,onoff,,,Set to TRUE (On) if "System Off" is selected
+r;w,,GlobalSystemOff,GlobalSystemOFF,,,,0700,,,onoff,,,Set to TRUE (On) if <System Off> is selected
 r;w,,ManualCooling,ManualCooling,,,,0600,,,UIN,,,"number of days of manual cooling. Max. days = 99. 0 days = off. Set temp via z1CoolingTemp."
 r;w,,ContinuosHeating,continuos heating,,,,0200,,,tempv,,,"-26=off, when the outside temperature falls below this threshold temperature the continuous heating function is started (off <=> function is disabled)"
 r;w,,FrostOverRideTime,frost delay time,,,,0300,,,hoursum2,,,delay before frost protection is activated
@@ -139,8 +139,8 @@ r;w,,Hc3SummerTempLimit,summer outside switchoff temperature heating circuit 3,,
 r;w,,Hc3RoomTempSwitchOn,RoomTempSwitchOn heating circuit 3,,,,1500,,,rcmode,,,room temperature modulation of Hc3
 r,,Hc3MixerMovement,MixerMovement heating circuit 3,,,,1A00,,,EXP,,,"status of mixer (<0 closing, >0 opening)"
 r,,Hc3HeatCurveAdaption,HeatCurveAdaption heating circuit 3,,,,1C00,,,EXP,,,adaption applied to heating curve of Hc3
-r;w,,Hc3Status,Status heating circuit 3,,,,1B00,,,UCH,,,status of zone 2
-r;w,,Hc3PumpStatus,PumpStatus heating circuit 3,,,,1E00,,,UIN,,,pump status of zone 3,,,,,,,,,,,,,
+r;w,,Hc3Status,Status heating circuit 3,,,,1B00,,,UCH,,,status of zone 3
+r;w,,Hc3PumpStatus,PumpStatus heating circuit 3,,,,1E00,,,UIN,,,pump status of zone 3
 # ##### zone 1 #####,,,,,,,,,,,,,
 *r,,,,,,B524,02000300,,,IGN:4,,,
 *w,,,,,,B524,02010300,,,,,,
@@ -206,7 +206,7 @@ r;w,,z3ActualRoomTempDesired,room temperature desired zone 3,,,,1400,,,tempv,,,c
 #r;w,,z3Unknown15Temp,(in noise reduction 24 otherwise 99 - max.air level?) temperature zone 3,,,,1500,,,tempv,,,unknown value for zone 3
 r;w,,z3Shortname,shortlabel zone 3,,,,1600,,,shortname,,,short name of zone 3
 r;w,,z3Name1,label zone 3 part 1,,,,1700,,,zname,,,name of zone 3
-r;w,,z3Name2,label zone 3 part 2,,,,1800,,,zname,,,name of zone 3,,,,,,,,,,,,,
+r;w,,z3Name2,label zone 3 part 2,,,,1800,,,zname,,,name of zone 3
 # ##### timers #####,,,,,,,,,,,,,
 # air,,,,,,,,,,,,,
 *r,,,,,,B524,03000001,,,IGN:1,,,whether timeslot is valid


### PR DESCRIPTION
Adds `ManualCooling` and `GlobalSytemOff` when VRC 700 is used. 

* The config line for `ManualCooling` was largely inspired by [kolibrie-eric:PR1](https://github.com/john30/ebusd-configuration/pull/160) (currently in _Draft_ state), with minor fixup and translation, so credit goes to @kolibrie-eric.
* The line for `GlobalSystemOff` was discovered using the steps described in the [wiki](https://github.com/john30/ebusd/wiki/HowTos#creating-new-message-definition-files) using `grab` and `grab result`. The wording was taken from file _15.370.csv_ (incl. the confusing fact that you have to send an ON in order to turn the system OFF)

Both lines, including the hex instructions, I could also see while grabbing instructions sent by the Vaillant "multiMATIC" app (via VR920). 

E.g. when choosing "System AUS" in the multimatic app I grabbed these messages:
```
1076b512030f0001 / 07b8030000801203 = 1
0015b52406020000007800 / 06030078000a00 = 2
0015b52406020003001b00 / 0601031b000a00 = 1
0015b5240702010000070001 / 020000 = 1
1076b51009000000ffffff050000 / 0101 = 1
```

whereas when aborting that state (= powering system ON again) I found these messages on the bus:
```
1076b512030f0001 / 07ba030000801203 = 1
0015b52406020000000700 / 050300070000 = 1
0015b52406020003001b00 / 0601031b000000 = 1
0015b5240702010000070000 / 020000 = 1
1076b51009000000ffffff010000 / 0101 = 1
```
