### PR TITLE
Updated special modes for VRC 700

### DIFF
--- a/ebusd-2.1.x/de/vaillant/_templates.csv
+++ b/ebusd-2.1.x/de/vaillant/_templates.csv
@@ -86,7 +86,7 @@ holiday,hfrom;hfrom;hto;hto,,,Ferienzeitraum 1 von; 2 von; 1 bis; 2 bis
 hpstatus,UCH,0=off;3=heat;6=standby;7=otshutdown;8=water,,Heizstatus
 frequency,UIN,,Hz,Frequenz
 zonesel,UIN,0=alle;1=1;2=2;3=3;4=4;5=5;6=6,,Selektierte Zone
-sfmode,UCH,0=auto;1=ventilation;2=party;3=veto;6=load,,
+sfmode,UCH,0=auto;1=ventilation;2=party;3=veto;4=onedayaway;5=onedayathome;6=hotwatercylinderboost,,
 opmode,UIN,0=off;1=auto;2=day;3=night,,
 zmapping,UIN,0=none;1=VRC700;2=VR91.1;3=VR91.2;4=VR91.3,,
 hcname,STR:11,,,Name des Heizkreises

--- a/ebusd-2.1.x/de/vaillant/_templates.csv
+++ b/ebusd-2.1.x/de/vaillant/_templates.csv
@@ -86,7 +86,7 @@ holiday,hfrom;hfrom;hto;hto,,,Ferienzeitraum 1 von; 2 von; 1 bis; 2 bis
 hpstatus,UCH,0=off;3=heat;6=standby;7=otshutdown;8=water,,Heizstatus
 frequency,UIN,,Hz,Frequenz
 zonesel,UIN,0=alle;1=1;2=2;3=3;4=4;5=5;6=6,,Selektierte Zone
-sfmode,UCH,0=auto;1=ventilation;2=party;3=veto;4=eintagaußerhaus;5=eintagzuhause;6=1xspeicherladung,,
+sfmode,UCH,0=auto;1=ventilation;2=party;3=veto;4=eintagaußerhaus;5=eintagzuhause;6=load,,
 opmode,UIN,0=off;1=auto;2=day;3=night,,
 zmapping,UIN,0=none;1=VRC700;2=VR91.1;3=VR91.2;4=VR91.3,,
 hcname,STR:11,,,Name des Heizkreises

--- a/ebusd-2.1.x/de/vaillant/_templates.csv
+++ b/ebusd-2.1.x/de/vaillant/_templates.csv
@@ -86,7 +86,7 @@ holiday,hfrom;hfrom;hto;hto,,,Ferienzeitraum 1 von; 2 von; 1 bis; 2 bis
 hpstatus,UCH,0=off;3=heat;6=standby;7=otshutdown;8=water,,Heizstatus
 frequency,UIN,,Hz,Frequenz
 zonesel,UIN,0=alle;1=1;2=2;3=3;4=4;5=5;6=6,,Selektierte Zone
-sfmode,UCH,0=auto;1=ventilation;2=party;3=veto;4=onedayaway;5=onedayathome;6=hotwatercylinderboost,,
+sfmode,UCH,0=auto;1=ventilation;2=party;3=veto;4=eintagaußerhaus;5=eintagzuhause;6=1xspeicherladung,,
 opmode,UIN,0=off;1=auto;2=day;3=night,,
 zmapping,UIN,0=none;1=VRC700;2=VR91.1;3=VR91.2;4=VR91.3,,
 hcname,STR:11,,,Name des Heizkreises


### PR DESCRIPTION
Some special operating modes are missing for VRC 700, added them. Successfully tested with VRC700/4. Not sure if English mode names fit for the German file. Please change to German if necessary.