### PR TITLE
Fix Sol/BufferPumpPower unit

### DIFF
--- a/ebusd-2.1.x/de/vaillant/06.pms.csv
+++ b/ebusd-2.1.x/de/vaillant/06.pms.csv
@@ -13,8 +13,8 @@ r,,Ntc2Sensor,NTC 2 Sensor,,,,"0600",,,tempsensor,,,Temperature in solar back fl
 r,,Ntc3Sensor,NTC 3 Sensor,,,,"0700",,,tempsensor,,,Temperature in buffer flow (to buffer)
 r,,Ntc4Sensor,NTC 4 Sensor,,,,"0800",,,tempsensor,,,Temperature in buffer back flow (from buffer)
 r;wi,,SolPumpRelay,Relais Solarpumpe,,,,"0F00",,,onoff,,,Solar pump relay: 0: OFF; 1: ON
-r;wi,,SolPumpPower,Leistung Solarpumpe,,,,"1000",,,power,,,Performance of solar pump: (7 - 100 %)
-r;wi,,BufferPumpPower,Leistung Pufferpumpe,,,,"1100",,,power,,,Performance of buffer pump: (15 - 100%)
+r;wi,,SolPumpPower,Leistung Solarpumpe,,,,"1000",,,percent,,,Performance of solar pump: (7 - 100 %)
+r;wi,,BufferPumpPower,Leistung Pufferpumpe,,,,"1100",,,percent,,,Performance of buffer pump: (15 - 100%)
 r,,MonitorMatlabLast5minSolAverage,MonitorMatlab_Last5minSolarAverage,,,,"1700",,,SIN,,,
 r,,CurrentSolTempDesired,Solar Zieltemperatur,,,,"1800",,,UIN,,°C,Temperature target in solar flow at sensor Ntc1Sensor
 r,,CurrentVPMLoadingMode,Aktuelle Betriebsart,,,,"1900",,,UCH,,,1 = Warmwasser (autonom)2 = Heizung (autonom)3 = +10K (autonom)4 = Schwimmbad5 = Warmwasser6 = Heizung7 = +10K

--- a/ebusd-2.1.x/de/vaillant/06.vms.csv
+++ b/ebusd-2.1.x/de/vaillant/06.vms.csv
@@ -7,8 +7,8 @@
 r,,Ntc1Sensor,NTC 1 Sensor,,,,"0500",,,tempsensor,,,Temperature in solar flow (from solar collector)
 r,,Ntc2Sensor,NTC 2 Sensor,,,,"0600",,,tempsensor,,,Temperature in solar back flow (to solar collector)
 r;wi,,SolPumpRelay,Relais Solarpumpe,,,,"0F00",,,onoff,,,Solar pump relay: 0: OFF; 1: ON
-r;wi,,SolPumpPower,Leistung Solarpumpe,,,,"1000",,,power,,,Performance of solar pump: (7 - 100 %)
-r;wi,,BufferPumpPower,Leistung Pufferpumpe,,,,"1100",,,power,,,Performance of buffer pump: (15 - 100%)
+r;wi,,SolPumpPower,Leistung Solarpumpe,,,,"1000",,,percent,,,Performance of solar pump: (7 - 100 %)
+r;wi,,BufferPumpPower,Leistung Pufferpumpe,,,,"1100",,,percent,,,Performance of buffer pump: (15 - 100%)
 r,,MonitorMatlabLast5minSolAverage,MonitorMatlab_Last5minSolarAverage,,,,"1700",,,SIN,,,
 r,,CurrentVPMLoadingMode,Aktuelle Betriebsart,,,,"1900",,,UCH,,,1 = Warmwasser (autonom)2 = Heizung (autonom)3 = +10K (autonom)4 = Schwimmbad5 = Warmwasser6 = Heizung7 = +10K
 r,,RunTimePump1Minutes,Laufzeit Pumpe 1,,,,"1A00",,,minutes0,,,Laufzeit der Solarpumpe (Minuten Anteil)

--- a/ebusd-2.1.x/en/vaillant/06.pms.csv
+++ b/ebusd-2.1.x/en/vaillant/06.pms.csv
@@ -13,8 +13,8 @@ r,,Ntc2Sensor,Ntc2Sensor,,,,"0600",,,tempsensor,,,Temperature in solar back flow
 r,,Ntc3Sensor,Ntc3Sensor,,,,"0700",,,tempsensor,,,Temperature in buffer flow (to buffer)
 r,,Ntc4Sensor,Ntc4Sensor,,,,"0800",,,tempsensor,,,Temperature in buffer back flow (from buffer)
 r;wi,,SolPumpRelay,Relais Solarpumpe,,,,"0F00",,,onoff,,,Solar pump relay: 0: OFF; 1: ON
-r;wi,,SolPumpPower,SolarPumpPower,,,,"1000",,,power,,,Performance of solar pump: (7 - 100 %)
-r;wi,,BufferPumpPower,BufferPumpPower,,,,"1100",,,power,,,Performance of buffer pump: (15 - 100%)
+r;wi,,SolPumpPower,SolarPumpPower,,,,"1000",,,percent,,,Performance of solar pump: (7 - 100 %)
+r;wi,,BufferPumpPower,BufferPumpPower,,,,"1100",,,percent,,,Performance of buffer pump: (15 - 100%)
 r,,MonitorMatlabLast5minSolAverage,MonitorMatlab_Last5minSolarAverage,,,,"1700",,,SIN,,,
 r,,CurrentSolTempDesired,CurrentSolarSetpoint,,,,"1800",,,UIN,,°C,Temperature target in solar flow at sensor Ntc1Sensor
 r,,CurrentVPMLoadingMode,CurrentVPM_LoadingMode,,,,"1900",,,UCH,,,"1. DHW-Support (stand alone), 2. CH-Support (stand alone), 3. +10K (stand alone), 4. SwimmingPool, 5.DHW-Support (with external control), 6. CH-Support (with external control), 7. +10K (with external control)"

--- a/ebusd-2.1.x/en/vaillant/06.vms.csv
+++ b/ebusd-2.1.x/en/vaillant/06.vms.csv
@@ -7,8 +7,8 @@
 r,,Ntc1Sensor,Ntc1Sensor,,,,"0500",,,tempsensor,,,Temperature in solar flow (from solar collector)
 r,,Ntc2Sensor,Ntc2Sensor,,,,"0600",,,tempsensor,,,Temperature in solar back flow (to solar collector)
 r;wi,,SolPumpRelay,Relais Solarpumpe,,,,"0F00",,,onoff,,,Solar pump relay: 0: OFF; 1: ON
-r;wi,,SolPumpPower,SolarPumpPower,,,,"1000",,,power,,,Performance of solar pump: (7 - 100 %)
-r;wi,,BufferPumpPower,BufferPumpPower,,,,"1100",,,power,,,Performance of buffer pump: (15 - 100%)
+r;wi,,SolPumpPower,SolarPumpPower,,,,"1000",,,percent,,,Performance of solar pump: (7 - 100 %)
+r;wi,,BufferPumpPower,BufferPumpPower,,,,"1100",,,percent,,,Performance of buffer pump: (15 - 100%)
 r,,MonitorMatlabLast5minSolAverage,MonitorMatlab_Last5minSolarAverage,,,,"1700",,,SIN,,,
 r,,CurrentVPMLoadingMode,CurrentVPM_LoadingMode,,,,"1900",,,UCH,,,"1. DHW-Support (stand alone), 2. CH-Support (stand alone), 3. +10K (stand alone), 4. SwimmingPool, 5.DHW-Support (with external control), 6. CH-Support (with external control), 7. +10K (with external control)"
 r,,RunTimePump1Minutes,RunTimePump1_Minutes,,,,"1A00",,,minutes0,,,Runtime of solar pump in minutes

--- a/src/vaillant/06.pms.tsp
+++ b/src/vaillant/06.pms.tsp
@@ -50,11 +50,11 @@ namespace Pms {
 
   /** SolarPumpPower: Performance of solar pump: (7 - 100 %) */
   @ext(0x10, 0)
-  model SolPumpPower is InstallRegister<power>;
+  model SolPumpPower is InstallRegister<percent>;
 
   /** BufferPumpPower: Performance of buffer pump: (15 - 100%) */
   @ext(0x11, 0)
-  model BufferPumpPower is InstallRegister<power>;
+  model BufferPumpPower is InstallRegister<percent>;
 
   /** MonitorMatlab_Last5minSolarAverage */
   @ext(0x17, 0)

--- a/src/vaillant/06.vms.tsp
+++ b/src/vaillant/06.vms.tsp
@@ -26,11 +26,11 @@ namespace Vms {
 
   /** SolarPumpPower: Performance of solar pump: (7 - 100 %) */
   @ext(0x10, 0)
-  model SolPumpPower is InstallRegister<power>;
+  model SolPumpPower is InstallRegister<percent>;
 
   /** BufferPumpPower: Performance of buffer pump: (15 - 100%) */
   @ext(0x11, 0)
-  model BufferPumpPower is InstallRegister<power>;
+  model BufferPumpPower is InstallRegister<percent>;
 
   /** MonitorMatlab_Last5minSolarAverage */
   @ext(0x17, 0)


### PR DESCRIPTION
SolPumpPower and BufferPumpPower should be expressed in % rather than in kW.

Similar to #430, but also fixes the source .tsp files.

Fixies john30/ebusd#1229