### PR TITLE
Added RunDataFlowTemp and RunDataReturnTemp in 08.hmu

### DIFF
--- a/src/vaillant/08.hmu.tsp
+++ b/src/vaillant/08.hmu.tsp
@@ -1516,6 +1516,20 @@ namespace Hmu {
   }
 
   @inherit(r_7)
+  @ext(0xfc, 0x8)
+  model RunDataFlowTemp {
+    /** current flow temp, accurate to 2 decimal places */
+    value: tempv;
+  }
+
+  @inherit(r_7)
+  @ext(0x6, 0x9)
+  model RunDataReturnTemp {
+    /** current return temp, accurate to 2 decimal places */
+    value: tempv;
+  }
+
+  @inherit(r_7)
   @ext(0xb8, 0xb)
   model RunStatsHMUHours {
     value: hoursum2;


### PR DESCRIPTION
see #446 

These work on "MF=Vaillant;ID=HMU00;SW=0902;HW=5103" and are useful to calculate COP of the heat pump as these are more accurate than the flow and return metrics that are already available for 08.hmu.