### PR TITLE
Add basic support for b516 energy statistics

### DIFF
--- a/src/vaillant/08.bai.tsp
+++ b/src/vaillant/08.bai.tsp
@@ -20,6 +20,7 @@ import "./bai.0010021901_inc.tsp";
 import "./bai.0010021961_inc.tsp";
 import "./bai.0010008045_inc.tsp";
 import "./hcmode_inc.tsp";
+import "./b516_inc.tsp";
 using Ebus;
 using Ebus.Num;
 using Ebus.Dtm;
@@ -381,5 +382,6 @@ namespace Bai {
 
     default: Bai._308523_inc, // final load alternative
     Hcmode_inc,
+    B516_inc,
   }
 }

--- a/src/vaillant/08.hmu.tsp
+++ b/src/vaillant/08.hmu.tsp
@@ -2,6 +2,7 @@ import "@ebusd/ebus-typespec";
 import "./_templates.tsp";
 import "./hcmode_inc.tsp";
 import "./errors_inc.tsp";
+import "./b516_inc.tsp";
 using Ebus;
 using Ebus.Num;
 using Ebus.Dtm;
@@ -1793,5 +1794,6 @@ namespace Hmu {
   union _includes {
     Hcmode_inc,
     Errors_inc,
+    B516_inc,
   }
 }

--- a/src/vaillant/15.ctlv2.tsp
+++ b/src/vaillant/15.ctlv2.tsp
@@ -1,6 +1,7 @@
 import "@ebusd/ebus-typespec";
 import "./_templates.tsp";
 import "./errors_inc.tsp";
+import "./b516_inc.tsp";
 using Ebus;
 using Ebus.Num;
 using Ebus.Dtm;
@@ -2551,5 +2552,6 @@ namespace Ctlv2 {
   /** included parts */
   union _includes {
     Errors_inc,
+    B516_inc,
   }
 }

--- a/src/vaillant/26.vr_71.tsp
+++ b/src/vaillant/26.vr_71.tsp
@@ -1,6 +1,7 @@
 import "@ebusd/ebus-typespec";
 import "./_templates.tsp";
 import "./errors_inc.tsp";
+import "./b516_inc.tsp";
 using Ebus;
 using Ebus.Num;
 using Ebus.Dtm;
@@ -194,5 +195,6 @@ namespace Vr_71 {
   /** included parts */
   union _includes {
     Errors_inc,
+    B516_inc,
   }
 }

--- a/src/vaillant/76.vwz.tsp
+++ b/src/vaillant/76.vwz.tsp
@@ -1,5 +1,6 @@
 import "@ebusd/ebus-typespec";
 import "./_templates.tsp";
+import "./b516_inc.tsp";
 using Ebus;
 using Ebus.Num;
 using Ebus.Dtm;
@@ -73,5 +74,10 @@ namespace Vwz {
   enum Values_TestThreeWayValve {
     heating: 0,
     dhw: 1,
+  }
+
+  /** included parts */
+  union _includes {
+    B516_inc,
   }
 }

--- a/src/vaillant/b516_inc.tsp
+++ b/src/vaillant/b516_inc.tsp
@@ -1,0 +1,104 @@
+import "@ebusd/ebus-typespec";
+import "./_templates.tsp";
+using Ebus;
+using Ebus.Num;
+using Ebus.Str;
+namespace Vaillant;
+
+/** b516 energy statistics */
+namespace B516_inc {
+
+  model energye {
+    @maxLength(7)
+    ign: IGN;
+    @unit("Wh")
+    energye: EXP;
+  }
+
+  @base(MF, 0x16, 0x10)
+  model r_1 {}
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x01, 0x00, 0x00, 0x30)
+  model SolarSumSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x01, 0x03, 0x00, 0x30)
+  model SolarHeatingSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x01, 0x04, 0x00, 0x30)
+  model SolarHotWaterSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x02, 0x00, 0x00, 0x30)
+  model EnvironmentalSumSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x02, 0x03, 0x00, 0x30)
+  model EnvironmentalHeatingSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x02, 0x04, 0x00, 0x30)
+  model EnvironmentalHotWaterSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x02, 0x05, 0x00, 0x30)
+  model EnvironmentalCoolingSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x03, 0x00, 0x00, 0x30)
+  model ElectricalSumSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x03, 0x03, 0x00, 0x30)
+  model ElectricalHeatingSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x03, 0x04, 0x00, 0x30)
+  model ElectricalHotWaterSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x03, 0x05, 0x00, 0x30)
+  model ElectricalCoolingSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x04, 0x00, 0x00, 0x30)
+  model FuelSumSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x04, 0x03, 0x00, 0x30)
+  model FuelHeatingSystem {
+    value: energye;
+  }
+
+  @inherit(r_1)
+  @ext(0x00, 0xff, 0xff, 0x04, 0x04, 0x00, 0x30)
+  model FuelHotWaterSystem {
+    value: energye;
+  }
+}


### PR DESCRIPTION
This PR introduces basic support for "b516" statistics present in some `bai` (possibly only present in HW: 7603) gas boilers and `hmu` heat pumps which don't support `PrEnergyCount*`/`PrEnergySum*` values.
Details are explained in the first post here: https://github.com/john30/ebusd-configuration/issues/490#issue-2883618064 and during the discussions there we came to an agreement that only 14 of most useful values are to be defined, although the script (https://gist.github.com/filippz/c0d04e4d607e27fc6b89d127db0ee941) can generate 10794 values based on our findings.

Testing and comments are welcome.