### PR TITLE
Update _templates.tsp add entry to enum daynight

### DIFF
--- a/src/vaillant/_templates.tsp
+++ b/src/vaillant/_templates.tsp
@@ -541,6 +541,7 @@ enum Values_mixer {
 enum Values_daynight {
   night: 0,
   day: 1,
+  instantload: 4,
   floorpaving: 7,
 }
 


### PR DESCRIPTION
I added an entry for the instant load status to the enum Values_daynight because of the error message I got: "Ignoring invalid option received on topic 'ebusd/hwc/Mode', got '4', allowed: night, day, floorpaving"