### PR TITLE
Add Vaillant ecoTEC 0010024646 configuration and models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 node_modules
 out*
 utils/dist
+/package-lock.json

--- a/ebusd-2.1.x/en/vaillant/bai.0010024646.inc
+++ b/ebusd-2.1.x/en/vaillant/bai.0010024646.inc
@@ -7,12 +7,17 @@
 *[SW],scan,,,SW,,,,,,,,,
 # ##### dia level 1 #####,,,,,,,,,,,,,
 r,,Statenumber,Statenumber_DK,,,,"AB00",,,UCH,,,status number
+r,,Status,Status,,,,"1103",,,UCH,,,System status
+r,,Status01,Status01,,,,"1101",,,HEX:10,,,Status information 1
+r,,Status02,Status02,,,,"1102",,,HEX:7,,,Status information 2
+r,,Status16,Status16,,,,"0416",,,UCH,,,Status information 16
 r;wi,,PartloadHcKW,d.00 heating partload,,,,"0704",,,power,,,Heating part load
 r;wi,,WPPostrunTime,d.01 central heating overruntime,,,,"F703",,,minutes0,,,water pump overrun time for heating mode
 r;wi,,BlockTimeHcMax,d.02 Max blocking time CH,,,,"0904",,,minutes0,,,max. burner anti cycling period at 20°C Flow temperature setpoint
 r,,HwcTemp,d.03 Temp DHW,,,,"1600",,,tempsensor,,,hot water flow temperature (combination boiler only)
 r,,StorageTemp,d.04 Temp storage / she,,,,"1700",,,tempsensor,,,current temperature for warm start sensor (combination boiler only) Current storage tank sensor (system boiler only)
 r,,FlowTempDesired,d.05 flow/return setpoint,,,,"3900",,,temp,,,Flow temperature target value or return target value when return regulation is set
+r,,HwcPostrunTime,Hot water pump overrun time,,,,"1104",,,minutes0,,,Hot water pump overrun time
 r,,StorageTempDesired,d.07 Storage setpoint,,,,"0400",,,temp,,,"Warm start temperature value (combination boiler plus only), Storage temperature target value (system boiler only)"
 r,,ACRoomthermostat,d.08 Room thermostat 230 V,,,,"2A00",,,onoff,,,External controls heat demand (Clamp 3-4)
 r,,ExtFlowTempDesiredMin,d.09 ext flowsetpoint,,,,"6E04",,,temp,,,minimum out of Kl.7 and eBus flow setpoint
@@ -23,12 +28,16 @@ r,,CirPump,d.13 Circulation pump,,,,"7B00",,,onoff,,,Hot water circulation pump 
 r,,HwcDemand,d.22 DHW demand,,,,"5800",,,yesno,,,domestic hot water (tapping or tank contact) demand
 r,,HeatingSwitch,d.23 operation mode,,,,"F203",,,onoff,,,Wintermode active
 r,,StoragereleaseClock,d.25 DHW demand enabled,,,,"4704",,,yesno,,,hot water release (tank storage) via eBus Control
+r,,ChangesDSN,ChangesDSN_DK,,,,"0C00",,,UCH,,,Numbers adjusting (storing) the DSN
+r,,ExternalFlowTempDesired,External flow temperature desired,,,,"2500",,,temp,,,External flow temperature desired
+r,,TempMaxDiffExtTFT,Maximum temperature difference,,,,"2700",,,temp,,,Maximum difference between external and flow temperature
 r,,Gasvalve,d.30 Gasvalve,,,,"BB00",,,onoff2,,,Gasvalve activation signal
 r,,TargetFanSpeed,d.33 Target fan speed,,,,"2400",,,UIN,,rpm,Fan speed setpoint
 r,,FanSpeed,d.34 Actual fan speed,,,,"8300",,,UIN,,rpm,fan speed actual value
 r,,PositionValveSet,d.35 Position TWV,,,,"5400",,,UCH,,,Position of diverter valve; 100 = DHW, 0 = heating, 40 = middle position
 r,,FlowTemp,d.40 TFT_DK,,,,"1800",,,tempsensor,,,flow temperature
 r,,ReturnTemp,d.41 Temp heating return,,,,"9800",,,tempmirrorsensor,,,return temperature
+r,,Expertlevel_ReturnTemp,Return temperature expert level,,,,"6B00",,,tempmirrorsensor,,,Return temperature on expert level
 r,,IonisationVoltageLevel,d.44 Dig. ionisation voltage,,,,"A400",,,SIN,10,,digital ionisation voltage> 80 no flame< 40 good flame
 r,,OutdoorstempSensor,d.47 Temp outside,,,,"7600",,,tempsensor,,,Outside temperature (uncorrected value)
 r,,RemainingBoilerblocktime,d.67 Remaining burner block time,,,,"3800",,,minutes0,,,Remaining burner anti cycling time
@@ -40,6 +49,7 @@ r,,CounterStartattempts1,d.68 ignition attempts 1,,,,"6E00",,,temp0,,,unsuccessf
 r,,CounterStartattempts2,d.69 ignition attempts 2,,,,"6F00",,,temp0,,,unsuccessfull ignitions in the second attempt
 r,,EBusHeatcontrol,d.90 Digital control recognized,,,,"0004",,,yesno,,,Digital regulator status
 r,,Flame,Flame,,,,"0500",,,onoff2,,,Flame status
+r,,PowerValue,Power value of the boiler,,,,"AA00",,,HEX:6,,,Power Values of the Boiler
 r,,FanHours,Fan operation hours,,,,"1B00",,,hoursum2,,h,Operating hours of the fan
 r,,FanStarts,FanCommunt_DK,,,,"1C00",,,cntstarts2,,,commutations of the fan
 r,,CounterStartAttempts3,CounterStartAttempts3_DK,,,,"8100",,,temp0,,,unsuccessfull ignitions in the third attempt
@@ -57,4 +67,46 @@ r,,PumpHours,PumpHours,,,,"5601",,,hoursum,,h,Pump operation hours
 r,,StorageLoadPumpHours,StorageLoadPumpHours,,,,"7301",,,hoursum,,h,Storage load pump operation hours
 r,,StorageloadPumpStarts,StorageloadPumpStarts,,,,"7303",,,cntstarts2,,,Storage load pump starts
 r,,ValveMode,ValveMode,,,,"F403",,,UCH,,,Valve mode
-r,,HcPumpMode,HcPumpMode,,,,"4E04",,,pumpmode,,,Heating pump mode 
+r,,HcPumpMode,HcPumpMode,,,,"4E04",,,pumpmode,,,Heating pump mode
+# Additional parameters found in grab result,,,,,,,,,,,,,
+r,,PumpHwcFlowSum,Pump hot water flow sum,,,,"C100",,,UIN,,,Pump hot water flow sum
+r,,PumpHwcFlowNumber,Pump hot water flow number,,,,"C200",,,UIN,,,Pump hot water flow number
+r,,DisplayMode,Display operation mode,,,,"DA00",,,UCH,,,Display operation mode
+r,,WaterpressureMeasureCounter,Water pressure measurement counter,,,,"F100",,,UCH,,,Water pressure measurement counter
+r,,PrAPSCounter,APS counter,,,,"F200",,,UCH,,,APS counter
+r,,PrVortexFlowSensorValue,Vortex flow sensor value,,,,"F400",,,UIN,,,Vortex flow sensor value
+r,,HwcUnderHundredStarts,Hot water starts under hundred counter,,,,"3100",,,UCH,,,Hot water starts under hundred counter
+r,,HcUnderHundredStarts,Heating starts under hundred counter,,,,"3000",,,UCH,,,Heating starts under hundred counter
+r,,SHEMaxFlowTemp,Secondary heat exchanger maximum flow temperature,,,,"C300",,,temp,,,Secondary heat exchanger maximum flow temperature
+r,,HwcTempMax,Maximum hot water temperature,,,,"4304",,,temp,,,Maximum hot water temperature
+r,,Maintenancedata_HwcTempMax,Maximum hot water temperature from maintenance,,,,"3500",,,temp,,,Maximum hot water temperature from maintenance data
+r,,StorageTempMax,Maximum storage temperature,,,,"3600",,,temp,,,Maximum storage temperature
+r,,FlowTempMax,Maximum flow temperature,,,,"3700",,,temp,,,Maximum flow temperature
+r,,ReturnTempMax,Maximum return temperature,,,,"BE00",,,temp,,,Maximum return temperature
+r,,ModulationTempDesired,Desired modulation temperature,,,,"2E00",,,temp,,,Desired modulation temperature
+r,,PumpPower,Pump power value,,,,"7300",,,UCH,,,Pump power value
+r,,PumpPowerDesired,Desired pump power,,,,"A100",,,UCH,,,Desired pump power
+r,,HwcWaterflow,Hot water flow rate,,,,"5500",,,uin100,,,Hot water flow rate
+r,,HwcWaterflowMax,Maximum hot water flow rate,,,,"5600",,,uin100,,,Maximum hot water flow rate
+r,,HwcImpellorSwitch,Hot water impellor switch,,,,"5700",,,yesno,,,Hot water impellor switch
+r,,VortexFlowSensor,Vortex flow sensor value,,,,"D500",,,UIN,,,Vortex flow sensor value
+r,,OverflowCounter,Overflow counter,,,,"1E00",,,yesno,,,Overflow counter
+r,,SecondPumpMode,Second pump mode,,,,"0B04",,,UCH,,,Second pump mode
+r,,ExternalHwcSwitch,External hot water circuit switch,,,,"0000",,,onoff,,,External hot water circuit switch
+r,,HwcTempDesired,Hot water temperature desired value,,,,"EA03",,,temp,,,Hot water temperature desired value
+r,,WarmstartDemand,Warm start demand,,,,"3A04",,,onoff,,,Warm start demand
+r,,Templimiter,Temperature limiter status,,,,"7700",,,onoff,,,Temperature limiter status
+r,,HoursTillService,Hours till next service,,,,"2004",,,ULG,,,Hours till next service
+r,,TimerInputHc,Timer input for heating circuit,,,,"DE00",,,onoff,,,Timer input for heating circuit
+r,,PrEnergySumHwc1,Energy sum hot water circuit 1,,,,"C500",,,UIN,,,Energy sum hot water circuit 1
+r,,PrEnergyCountHwc1,Energy count hot water circuit 1,,,,"C600",,,UIN,,,Energy count hot water circuit 1
+r,,PrEnergySumHwc2,Energy sum hot water circuit 2,,,,"C700",,,UIN,,,Energy sum hot water circuit 2
+r,,PrEnergyCountHwc2,Energy count hot water circuit 2,,,,"C800",,,UIN,,,Energy count hot water circuit 2
+r,,PrEnergySumHwc3,Energy sum hot water circuit 3,,,,"C900",,,UIN,,,Energy sum hot water circuit 3
+r,,PrEnergyCountHwc3,Energy count hot water circuit 3,,,,"CA00",,,UIN,,,Energy count hot water circuit 3
+r,,PrEnergySumHc1,Energy sum heating circuit 1,,,,"F500",,,UIN,,,Energy sum heating circuit 1
+r,,PrEnergyCountHc1,Energy count heating circuit 1,,,,"F600",,,UIN,,,Energy count heating circuit 1
+r,,PrEnergySumHc2,Energy sum heating circuit 2,,,,"F700",,,UIN,,,Energy sum heating circuit 2
+r,,PrEnergyCountHc2,Energy count heating circuit 2,,,,"F800",,,UIN,,,Energy count heating circuit 2
+r,,PrEnergySumHc3,Energy sum heating circuit 3,,,,"F900",,,UIN,,,Energy sum heating circuit 3
+r,,PrEnergyCountHc3,Energy count heating circuit 3,,,,"FA00",,,UIN,,,Energy count heating circuit 3 

--- a/ebusd-2.1.x/en/vaillant/bai.0010024646.inc
+++ b/ebusd-2.1.x/en/vaillant/bai.0010024646.inc
@@ -1,112 +1,116 @@
-# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates,divider/values,unit,comment
-#,BAI00,Vaillant ecoTEC,0010024646,,,,,,,,,,
-*r,,,,,,"B509","0D",,,,,,
-*w,,,,,,"B509","0E",,,,,,
-*wi,#install,,,,,"B509","0E",,,,,,
-*ws,#service,,,,,"B509","0E",,,,,,
-*[SW],scan,,,SW,,,,,,,,,
-# ##### dia level 1 #####,,,,,,,,,,,,,
-r,,Statenumber,Statenumber_DK,,,,"AB00",,,UCH,,,status number
-r,,Status,Status,,,,"1103",,,UCH,,,System status
-r,,Status01,Status01,,,,"1101",,,HEX:10,,,Status information 1
-r,,Status02,Status02,,,,"1102",,,HEX:7,,,Status information 2
-r,,Status16,Status16,,,,"0416",,,UCH,,,Status information 16
-r;wi,,PartloadHcKW,d.00 heating partload,,,,"0704",,,power,,,Heating part load
-r;wi,,WPPostrunTime,d.01 central heating overruntime,,,,"F703",,,minutes0,,,water pump overrun time for heating mode
-r;wi,,BlockTimeHcMax,d.02 Max blocking time CH,,,,"0904",,,minutes0,,,max. burner anti cycling period at 20°C Flow temperature setpoint
-r,,HwcTemp,d.03 Temp DHW,,,,"1600",,,tempsensor,,,hot water flow temperature (combination boiler only)
-r,,StorageTemp,d.04 Temp storage / she,,,,"1700",,,tempsensor,,,current temperature for warm start sensor (combination boiler only) Current storage tank sensor (system boiler only)
-r,,FlowTempDesired,d.05 flow/return setpoint,,,,"3900",,,temp,,,Flow temperature target value or return target value when return regulation is set
-r,,HwcPostrunTime,Hot water pump overrun time,,,,"1104",,,minutes0,,,Hot water pump overrun time
-r,,StorageTempDesired,d.07 Storage setpoint,,,,"0400",,,temp,,,"Warm start temperature value (combination boiler plus only), Storage temperature target value (system boiler only)"
-r,,ACRoomthermostat,d.08 Room thermostat 230 V,,,,"2A00",,,onoff,,,External controls heat demand (Clamp 3-4)
-r,,ExtFlowTempDesiredMin,d.09 ext flowsetpoint,,,,"6E04",,,temp,,,minimum out of Kl.7 and eBus flow setpoint
-r,,WP,d.10 Central heating pump,,,,"4400",,,onoff,,,internal heating pump
-r,,ExtWP,d.11 external pump,,,,"3F00",,,onoff,,,External heating pump
-r,,Storageloadpump,d.12 storage load pump,,,,"9E00",,,percent0,,,tank load pump demand
-r,,CirPump,d.13 Circulation pump,,,,"7B00",,,onoff,,,Hot water circulation pump (via external module)
-r,,HwcDemand,d.22 DHW demand,,,,"5800",,,yesno,,,domestic hot water (tapping or tank contact) demand
-r,,HeatingSwitch,d.23 operation mode,,,,"F203",,,onoff,,,Wintermode active
-r,,StoragereleaseClock,d.25 DHW demand enabled,,,,"4704",,,yesno,,,hot water release (tank storage) via eBus Control
-r,,ChangesDSN,ChangesDSN_DK,,,,"0C00",,,UCH,,,Numbers adjusting (storing) the DSN
-r,,ExternalFlowTempDesired,External flow temperature desired,,,,"2500",,,temp,,,External flow temperature desired
-r,,TempMaxDiffExtTFT,Maximum temperature difference,,,,"2700",,,temp,,,Maximum difference between external and flow temperature
-r,,Gasvalve,d.30 Gasvalve,,,,"BB00",,,onoff2,,,Gasvalve activation signal
-r,,TargetFanSpeed,d.33 Target fan speed,,,,"2400",,,UIN,,rpm,Fan speed setpoint
-r,,FanSpeed,d.34 Actual fan speed,,,,"8300",,,UIN,,rpm,fan speed actual value
-r,,PositionValveSet,d.35 Position TWV,,,,"5400",,,UCH,,,Position of diverter valve; 100 = DHW, 0 = heating, 40 = middle position
-r,,FlowTemp,d.40 TFT_DK,,,,"1800",,,tempsensor,,,flow temperature
-r,,ReturnTemp,d.41 Temp heating return,,,,"9800",,,tempmirrorsensor,,,return temperature
-r,,Expertlevel_ReturnTemp,Return temperature expert level,,,,"6B00",,,tempmirrorsensor,,,Return temperature on expert level
-r,,IonisationVoltageLevel,d.44 Dig. ionisation voltage,,,,"A400",,,SIN,10,,digital ionisation voltage> 80 no flame< 40 good flame
-r,,OutdoorstempSensor,d.47 Temp outside,,,,"7600",,,tempsensor,,,Outside temperature (uncorrected value)
-r,,RemainingBoilerblocktime,d.67 Remaining burner block time,,,,"3800",,,minutes0,,,Remaining burner anti cycling time
-r,,DeactivationsTemplimiter,d.60 Number STL cut off,,,,"2000",,,UCH,,,Number of safety temperature limiter cut offs
-r,,DeactivationsIFC,d.61 Number ignition device cut off,,,,"1F00",,,UCH,,,number of lock outs (unsuccessfull ignitons in the last attempt, flame failure)
-r,,AverageIgnitiontime,d.64 average ignition time,,,,"2D00",,,UCH,10,s,average ignition time
-r,,MaxIgnitiontime,d.65 Max ignition time,,,,"2C00",,,UCH,10,s,maximum ignition time
-r,,CounterStartattempts1,d.68 ignition attempts 1,,,,"6E00",,,temp0,,,unsuccessfull ignitions in the first attempt
-r,,CounterStartattempts2,d.69 ignition attempts 2,,,,"6F00",,,temp0,,,unsuccessfull ignitions in the second attempt
-r,,EBusHeatcontrol,d.90 Digital control recognized,,,,"0004",,,yesno,,,Digital regulator status
-r,,Flame,Flame,,,,"0500",,,onoff2,,,Flame status
-r,,PowerValue,Power value of the boiler,,,,"AA00",,,HEX:6,,,Power Values of the Boiler
-r,,FanHours,Fan operation hours,,,,"1B00",,,hoursum2,,h,Operating hours of the fan
-r,,FanStarts,FanCommunt_DK,,,,"1C00",,,cntstarts2,,,commutations of the fan
-r,,CounterStartAttempts3,CounterStartAttempts3_DK,,,,"8100",,,temp0,,,unsuccessfull ignitions in the third attempt
-r,,CounterStartAttempts4,CounterStartAttempts4_DK,,,,"8200",,,temp0,,,unsuccessfull ignitions in the fourth attempt
-r,,TempDiffBlock,TempDiffBlock_DK,,,,"1200",,,temp0,,,Number of modulationblocking of the boilers cause of to high/incorrect difference of flow/return temperatures
-r,,TempDiffFailure,TempDiffFailure_DK,,,,"1300",,,temp0,,,Number of cut offs of the boilers cause of to high/incorrect differences of flow/return temperatures
-r,,ValveStarts,TWV_Communt_DK,,,,"1A00",,,cntstarts2,,,commutations of the three way valve
-r,,TemplimiterWithNTC,TemplimiterWithNTC,,,,"D200",,,yesno2,,,Safety temperature limit concept
-r,,HcHours,HcHours,,,,"3801",,,hoursum,,h,Central heating operation hours
-r,,HcPumpStarts,HcPumpStarts,,,,"5603",,,cntstarts3,,,Central heating pump starts
-r,,HcStarts,HcStarts,,,,"3803",,,cntstarts2,,,Central heating burner starts
-r,,HwcHours,HwcHours,,,,"7701",,,hoursum,,h,Hot water operation hours
-r,,HwcStarts,HwcStarts,,,,"7703",,,cntstarts2,,,Hot water burner starts
-r,,PumpHours,PumpHours,,,,"5601",,,hoursum,,h,Pump operation hours
-r,,StorageLoadPumpHours,StorageLoadPumpHours,,,,"7301",,,hoursum,,h,Storage load pump operation hours
-r,,StorageloadPumpStarts,StorageloadPumpStarts,,,,"7303",,,cntstarts2,,,Storage load pump starts
-r,,ValveMode,ValveMode,,,,"F403",,,UCH,,,Valve mode
-r,,HcPumpMode,HcPumpMode,,,,"4E04",,,pumpmode,,,Heating pump mode
-# Additional parameters found in grab result,,,,,,,,,,,,,
-r,,PumpHwcFlowSum,Pump hot water flow sum,,,,"C100",,,UIN,,,Pump hot water flow sum
-r,,PumpHwcFlowNumber,Pump hot water flow number,,,,"C200",,,UIN,,,Pump hot water flow number
-r,,DisplayMode,Display operation mode,,,,"DA00",,,UCH,,,Display operation mode
-r,,WaterpressureMeasureCounter,Water pressure measurement counter,,,,"F100",,,UCH,,,Water pressure measurement counter
-r,,PrAPSCounter,APS counter,,,,"F200",,,UCH,,,APS counter
-r,,PrVortexFlowSensorValue,Vortex flow sensor value,,,,"F400",,,UIN,,,Vortex flow sensor value
-r,,HwcUnderHundredStarts,Hot water starts under hundred counter,,,,"3100",,,UCH,,,Hot water starts under hundred counter
-r,,HcUnderHundredStarts,Heating starts under hundred counter,,,,"3000",,,UCH,,,Heating starts under hundred counter
-r,,SHEMaxFlowTemp,Secondary heat exchanger maximum flow temperature,,,,"C300",,,temp,,,Secondary heat exchanger maximum flow temperature
-r,,HwcTempMax,Maximum hot water temperature,,,,"4304",,,temp,,,Maximum hot water temperature
-r,,Maintenancedata_HwcTempMax,Maximum hot water temperature from maintenance,,,,"3500",,,temp,,,Maximum hot water temperature from maintenance data
-r,,StorageTempMax,Maximum storage temperature,,,,"3600",,,temp,,,Maximum storage temperature
-r,,FlowTempMax,Maximum flow temperature,,,,"3700",,,temp,,,Maximum flow temperature
-r,,ReturnTempMax,Maximum return temperature,,,,"BE00",,,temp,,,Maximum return temperature
-r,,ModulationTempDesired,Desired modulation temperature,,,,"2E00",,,temp,,,Desired modulation temperature
-r,,PumpPower,Pump power value,,,,"7300",,,UCH,,,Pump power value
-r,,PumpPowerDesired,Desired pump power,,,,"A100",,,UCH,,,Desired pump power
-r,,HwcWaterflow,Hot water flow rate,,,,"5500",,,uin100,,,Hot water flow rate
-r,,HwcWaterflowMax,Maximum hot water flow rate,,,,"5600",,,uin100,,,Maximum hot water flow rate
-r,,HwcImpellorSwitch,Hot water impellor switch,,,,"5700",,,yesno,,,Hot water impellor switch
-r,,VortexFlowSensor,Vortex flow sensor value,,,,"D500",,,UIN,,,Vortex flow sensor value
-r,,OverflowCounter,Overflow counter,,,,"1E00",,,yesno,,,Overflow counter
-r,,SecondPumpMode,Second pump mode,,,,"0B04",,,UCH,,,Second pump mode
-r,,ExternalHwcSwitch,External hot water circuit switch,,,,"0000",,,onoff,,,External hot water circuit switch
-r,,HwcTempDesired,Hot water temperature desired value,,,,"EA03",,,temp,,,Hot water temperature desired value
-r,,WarmstartDemand,Warm start demand,,,,"3A04",,,onoff,,,Warm start demand
-r,,Templimiter,Temperature limiter status,,,,"7700",,,onoff,,,Temperature limiter status
-r,,HoursTillService,Hours till next service,,,,"2004",,,ULG,,,Hours till next service
-r,,TimerInputHc,Timer input for heating circuit,,,,"DE00",,,onoff,,,Timer input for heating circuit
-r,,PrEnergySumHwc1,Energy sum hot water circuit 1,,,,"C500",,,UIN,,,Energy sum hot water circuit 1
-r,,PrEnergyCountHwc1,Energy count hot water circuit 1,,,,"C600",,,UIN,,,Energy count hot water circuit 1
-r,,PrEnergySumHwc2,Energy sum hot water circuit 2,,,,"C700",,,UIN,,,Energy sum hot water circuit 2
-r,,PrEnergyCountHwc2,Energy count hot water circuit 2,,,,"C800",,,UIN,,,Energy count hot water circuit 2
-r,,PrEnergySumHwc3,Energy sum hot water circuit 3,,,,"C900",,,UIN,,,Energy sum hot water circuit 3
-r,,PrEnergyCountHwc3,Energy count hot water circuit 3,,,,"CA00",,,UIN,,,Energy count hot water circuit 3
-r,,PrEnergySumHc1,Energy sum heating circuit 1,,,,"F500",,,UIN,,,Energy sum heating circuit 1
-r,,PrEnergyCountHc1,Energy count heating circuit 1,,,,"F600",,,UIN,,,Energy count heating circuit 1
-r,,PrEnergySumHc2,Energy sum heating circuit 2,,,,"F700",,,UIN,,,Energy sum heating circuit 2
-r,,PrEnergyCountHc2,Energy count heating circuit 2,,,,"F800",,,UIN,,,Energy count heating circuit 2
-r,,PrEnergySumHc3,Energy sum heating circuit 3,,,,"F900",,,UIN,,,Energy sum heating circuit 3
-r,,PrEnergyCountHc3,Energy count heating circuit 3,,,,"FA00",,,UIN,,,Energy count heating circuit 3 
+type,circuit,level,name,comment,qq,zz,pbsb,id,*name,part,type,divisor/values,unit,comment
+*r,
+*w,
+r,,,Statenumber,Statenumber_DK: status number,,,b509,0dab00,value,,UCH,,,
+r,,,PartloadHcKW,d.00 heating partload: Heating part load,,,b509,0d0704,value,,UCH,,kW,
+w,,install,PartloadHcKW,d.00 heating partload: Heating part load,,,b509,0e0704,value,,UCH,,kW,
+r,,,WPPostrunTime,d.01 central heating overruntime: water pump overrun time for heating mode,,,b509,0df703,value,,UCH,,min,minutes
+w,,install,WPPostrunTime,d.01 central heating overruntime: water pump overrun time for heating mode,,,b509,0ef703,value,,UCH,,min,minutes
+r,,,BlockTimeHcMax,d.02 Max blocking time CH: max. burner anti cycling period at 20°C Flow temperature setpoint,,,b509,0d0904,value,,UCH,,min,minutes
+w,,install,BlockTimeHcMax,d.02 Max blocking time CH: max. burner anti cycling period at 20°C Flow temperature setpoint,,,b509,0e0904,value,,UCH,,min,minutes
+r,,,HwcTemp,d.03 Temp DHW: hot water flow temperature (combination boiler only),,,b509,0d1600,temp,,D2C,,°C,temperature,sensor,,UCH,0=ok;85=circuit;170=cutoff,,sensor status
+r,,,StorageTemp,d.04 Temp storage / she: current temperature for warm start sensor (combination boiler only) Current storage tank sensor (system boiler only),,,b509,0d1700,temp,,D2C,,°C,temperature,sensor,,UCH,0=ok;85=circuit;170=cutoff,,sensor status
+r,,,FlowTempDesired,d.05 flow/return setpoint: Flow temperature target value or return target value when return regulation is set,,,b509,0d3900,value,,D2C,,°C,temperature
+r,,,StorageTempDesired,"d.07 Storage setpoint: Warm start temperature value (combination boiler plus only), Storage temperature target value (system boiler only)",,,b509,0d0400,value,,D2C,,°C,temperature
+r,,,ACRoomthermostat,d.08 Room thermostat 230 V: External controls heat demand (Clamp 3-4),,,b509,0d2a00,value,,UCH,0=off;1=on,,
+r,,,ExtFlowTempDesiredMin,d.09 ext flowsetpoint: minimum out of Kl.7 and eBus flow setpoint,,,b509,0d6e04,value,,D2C,,°C,temperature
+r,,,WP,d.10 Central heating pump: internal heating pump,,,b509,0d4400,value,,UCH,0=off;1=on,,
+r,,,ExtWP,d.11 external pump: External heating pump,,,b509,0d3f00,value,,UCH,0=off;1=on,,
+r,,,Storageloadpump,d.12 storage load pump: tank load pump demand,,,b509,0d9e00,value,,UCH,,%,
+r,,,CirPump,d.13 Circulation pump: Hot water circulation pump (via external module),,,b509,0d7b00,value,,UCH,0=off;1=on,,
+r,,,HwcDemand,d.22 DHW demand: domestic hot water (tapping or tank contact) demand,,,b509,0d5800,value,,UCH,0=no;1=yes,,
+r,,,HeatingSwitch,d.23 operation mode: Wintermode active,,,b509,0df203,value,,UCH,0=off;1=on,,
+r,,,StoragereleaseClock,d.25 DHW demand enabled: hot water release (tank storage) via eBus Control,,,b509,0d4704,value,,UCH,0=no;1=yes,,
+r,,,Gasvalve,d.30 Gasvalve: Gasvalve activation signal,,,b509,0dbb00,value,,UCH,240=off;15=on,,
+r,,,TargetFanSpeed,d.33 Target fan speed,,,b509,0d2400,value,,UIN,,1/min,Fan speed setpoint
+r,,,FanSpeed,d.34 Actual fan speed,,,b509,0d8300,value,,UIN,,1/min,fan speed actual value
+r,,,PositionValveSet,"d.35 Position TWV: Position of diverter valve; 100 = DHW, 0 = heating, 40 = middle position",,,b509,0d5400,value,,UCH,,,
+r,,,FlowTemp,d.40 TFT_DK: flow temperature,,,b509,0d1800,temp,,D2C,,°C,temperature,sensor,,UCH,0=ok;85=circuit;170=cutoff,,sensor status
+r,,,ReturnTemp,d.41 Temp heating return: return temperature,,,b509,0d9800,temp,,D2C,,°C,temperature,tempmirror,,UIN,,,,sensor,,UCH,0=ok;85=circuit;170=cutoff,,sensor status
+r,,,IonisationVoltageLevel,d.44 Dig. ionisation voltage,,,b509,0da400,value,,SIN,10,,digital ionisation voltage> 80 no flame< 40 good flame
+r,,,OutdoorstempSensor,d.47 Temp outside: Outside temperature (uncorrected value),,,b509,0d7600,temp,,D2C,,°C,temperature,sensor,,UCH,0=ok;85=circuit;170=cutoff,,sensor status
+r,,,DeactivationsTemplimiter,d.60 Number STL cut off: Number of safety temperature limiter cut offs,,,b509,0d2000,value,,UCH,,,
+r,,,DeactivationsIFC,"d.61 Number ignition device cut off: number of lock outs (unsuccessfull ignitons in the last attempt, flame failure)",,,b509,0d1f00,value,,UCH,,,
+r,,,AverageIgnitiontime,d.64 average ignition time,,,b509,0d2d00,value,,UCH,10,s,average ignition time
+r,,,MaxIgnitiontime,d.65 Max ignition time,,,b509,0d2c00,value,,UCH,10,s,maximum ignition time
+r,,,RemainingBoilerblocktime,d.67 Remaining burner block time: Remaining burner anti cycling time,,,b509,0d3800,value,,UCH,,min,minutes
+r,,,CounterStartattempts1,d.68 ignition attempts 1: unsuccessfull ignitions in the first attempt,,,b509,0d6e00,value,,UCH,,°C,temperature
+r,,,CounterStartattempts2,d.69 ignition attempts 2: unsuccessfull ignitions in the second attempt,,,b509,0d6f00,value,,UCH,,°C,temperature
+r,,,EBusHeatcontrol,d.90 Digital control recognized: Digital regulator status,,,b509,0d0004,value,,UCH,0=no;1=yes,,
+r,,,Flame,Flame,,,b509,0d0500,value,,UCH,240=off;15=on,,
+r,,,FanHours,Fan operation hours,,,b509,0d1b00,value,,UIN,,h,hours
+r,,,FanStarts,FanCommunt_DK: commutations of the fan,,,b509,0d1c00,value,,UIN,,,start count
+r,,,CounterStartAttempts3,CounterStartAttempts3_DK: unsuccessfull ignitions in the third attempt,,,b509,0d8100,value,,UCH,,°C,temperature
+r,,,CounterStartAttempts4,CounterStartAttempts4_DK: unsuccessfull ignitions in the fourth attempt,,,b509,0d8200,value,,UCH,,°C,temperature
+r,,,TempDiffBlock,TempDiffBlock_DK: Number of modulationblocking of the boilers cause of to high/incorrect difference of flow/return temperatures,,,b509,0d1200,value,,UCH,,°C,temperature
+r,,,TempDiffFailure,TempDiffFailure_DK: Number of cut offs of the boilers cause of to high/incorrect differences of flow/return temperatures,,,b509,0d1300,value,,UCH,,°C,temperature
+r,,,ValveStarts,TWV_Communt_DK: commutations of the three way valve,,,b509,0d1a00,value,,UIN,,,start count
+r,,,TemplimiterWithNTC,TemplimiterWithNTC: Safety temperature limit concept,,,b509,0dd200,value,,UCH,240=no;15=yes,,
+r,,,HcHours,HcHours: Central heating operation hours,,,b509,0d3801,value,,ULG,,h,hours
+r,,,HcPumpStarts,HcPumpStarts: Central heating pump starts,,,b509,0d5603,value,,UCH,,,
+r,,,HcStarts,HcStarts: Central heating burner starts,,,b509,0d3803,value,,UCH,,,
+r,,,HwcHours,HwcHours: Hot water operation hours,,,b509,0d7701,value,,ULG,,h,hours
+r,,,HwcStarts,HwcStarts: Hot water burner starts,,,b509,0d7703,value,,UIN,,,start count
+r,,,PumpHours,PumpHours: Pump operation hours,,,b509,0d5601,value,,ULG,,h,hours
+r,,,StorageLoadPumpHours,StorageLoadPumpHours: Storage load pump operation hours,,,b509,0d7301,value,,ULG,,h,hours
+r,,,StorageloadPumpStarts,StorageloadPumpStarts: Storage load pump starts,,,b509,0d7303,value,,UIN,,,start count
+r,,,ValveMode,Valve mode,,,b509,0df403,value,,UCH,,,
+r,,,HcPumpMode,HcPumpMode: Heating pump mode,,,b509,0d4e04,value,,UCH,,,
+r,,,DisplayMode,Dodane parametry na podstawie wyników komendy grabDisplayMode: Display operation mode,,,b509,0dda00,value,,UCH,,,
+r,,,WaterpressureMeasureCounter,WaterpressureMeasureCounter: Water pressure measurement counter,,,b509,0df100,value,,UCH,,,
+r,,,HwcUnderHundredStarts,HwcUnderHundredStarts: Hot water starts under hundred counter,,,b509,0d3100,value,,UCH,,,
+r,,,HcUnderHundredStarts,HcUnderHundredStarts: Heating starts under hundred counter,,,b509,0d3000,value,,UCH,,,
+r,,,SHEMaxFlowTemp,SHEMaxFlowTemp: Secondary heat exchanger maximum flow temperature,,,b509,0dc300,value,,D2C,,°C,temperature
+r,,,HwcTempMax,HwcTempMax: Maximum hot water temperature,,,b509,0d4304,value,,D2C,,°C,temperature
+r,,,Maintenancedata_HwcTempMax,Maintenancedata_HwcTempMax: Maximum hot water temperature from maintenance data,,,b509,0d3500,value,,D2C,,°C,temperature
+r,,,StorageTempMax,StorageTempMax: Maximum storage temperature,,,b509,0d3600,value,,D2C,,°C,temperature
+r,,,FlowTempMax,FlowTempMax: Maximum flow temperature,,,b509,0d3700,value,,D2C,,°C,temperature
+r,,,ReturnTempMax,ReturnTempMax: Maximum return temperature,,,b509,0dbe00,value,,D2C,,°C,temperature
+r,,,ModulationTempDesired,ModulationTempDesired: Desired modulation temperature,,,b509,0d2e00,value,,D2C,,°C,temperature
+r,,,PumpPower,PumpPower: Pump power value,,,b509,0d7300,value,,UCH,,,
+r,,,PumpPowerDesired,PumpPowerDesired: Desired pump power,,,b509,0da100,value,,UCH,,,
+r,,,HwcWaterflow,HwcWaterflow: Hot water flow rate,,,b509,0d5500,value,,UIN,100,,
+r,,,HwcWaterflowMax,HwcWaterflowMax: Maximum hot water flow rate,,,b509,0d5600,value,,UIN,100,,
+r,,,HwcImpellorSwitch,HwcImpellorSwitch: Hot water impellor switch,,,b509,0d5700,value,,UCH,0=no;1=yes,,
+r,,,VortexFlowSensor,VortexFlowSensor: Vortex flow sensor value,,,b509,0dd500,value,,UIN,,,
+r,,,OverflowCounter,OverflowCounter: Overflow counter,,,b509,0d1e00,value,,UCH,0=no;1=yes,,
+r,,,SecondPumpMode,SecondPumpMode: Second pump mode,,,b509,0d0b04,value,,UCH,,,
+r,,,ExternalHwcSwitch,ExternalHwcSwitch: External hot water circuit switch,,,b509,0d0000,value,,UCH,0=off;1=on,,
+r,,,HwcTempDesired,HwcTempDesired: Hot water temperature desired value,,,b509,0dea03,value,,D2C,,°C,temperature
+r,,,WarmstartDemand,WarmstartDemand: Warm start demand,,,b509,0d3a04,value,,UCH,0=off;1=on,,
+r,,,Templimiter,Templimiter: Temperature limiter status,,,b509,0d7700,value,,UCH,0=off;1=on,,
+r,,,HoursTillService,HoursTillService: Hours till next service,,,b509,0d2004,value,,ULG,,,
+r,,,TimerInputHc,TimerInputHc: Timer input for heating circuit,,,b509,0dde00,value,,UCH,0=off;1=on,,
+r,,,PrEnergySumHwc1,PrEnergySumHwc1: Energy sum hot water circuit 1,,,b509,0dc500,value,,UIN,,,
+r,,,PrEnergyCountHwc1,PrEnergyCountHwc1: Energy count hot water circuit 1,,,b509,0dc600,value,,UIN,,,
+r,,,PrEnergySumHwc2,PrEnergySumHwc2: Energy sum hot water circuit 2,,,b509,0dc700,value,,UIN,,,
+r,,,PrEnergyCountHwc2,PrEnergyCountHwc2: Energy count hot water circuit 2,,,b509,0dc800,value,,UIN,,,
+r,,,PrEnergySumHwc3,PrEnergySumHwc3: Energy sum hot water circuit 3,,,b509,0dc900,value,,UIN,,,
+r,,,PrEnergyCountHwc3,PrEnergyCountHwc3: Energy count hot water circuit 3,,,b509,0dca00,value,,UIN,,,
+r,,,PrEnergySumHc1,PrEnergySumHc1: Energy sum heating circuit 1,,,b509,0df500,value,,UIN,,,
+r,,,PrEnergyCountHc1,PrEnergyCountHc1: Energy count heating circuit 1,,,b509,0df600,value,,UIN,,,
+r,,,PrEnergySumHc2,PrEnergySumHc2: Energy sum heating circuit 2,,,b509,0df700,value,,UIN,,,
+r,,,PrEnergyCountHc2,PrEnergyCountHc2: Energy count heating circuit 2,,,b509,0df800,value,,UIN,,,
+r,,,PrEnergySumHc3,PrEnergySumHc3: Energy sum heating circuit 3,,,b509,0df900,value,,UIN,,,
+r,,,PrEnergyCountHc3,PrEnergyCountHc3: Energy count heating circuit 3,,,b509,0dfa00,value,,UIN,,,
+r,,,PumpHwcFlowSum,PumpHwcFlowSum: Pump hot water flow sum,,,b509,0dc100,value,,UIN,,,
+r,,,PumpHwcFlowNumber,PumpHwcFlowNumber: Pump hot water flow number,,,b509,0dc200,value,,UIN,,,
+r,,,PrAPSCounter,PrAPSCounter: APS counter,,,b509,0df200,value,,UCH,,,
+r,,,PrVortexFlowSensorValue,PrVortexFlowSensorValue: Vortex flow sensor value (legacy name),,,b509,0df400,value,,UIN,,,
+r,,,HwcPostrunTime,HwcPostrunTime: Hot water pump overrun time,,,b509,0d1104,value,,UCH,,min,minutes
+r,,,ChangesDSN,ChangesDSN: Numbers adjusting (storing) the DSN,,,b509,0d0c00,value,,UCH,,,
+r,,,ExternalFlowTempDesired,ExternalFlowTempDesired: External flow temperature desired,,,b509,0d2500,value,,D2C,,°C,temperature
+r,,,TempMaxDiffExtTFT,TempMaxDiffExtTFT: Maximum temperature difference,,,b509,0d2700,value,,D2C,,°C,temperature
+r,,,Expertlevel_ReturnTemp,Expertlevel_ReturnTemp: Return temperature expert level,,,b509,0d6b00,temp,,D2C,,°C,temperature,tempmirror,,UIN,,,,sensor,,UCH,0=ok;85=circuit;170=cutoff,,sensor status
+r,,,PowerValue,PowerValue: Power value of the boiler,,,b509,0daa00,value,,HEX:6,,,Power value of the boiler (minimum and maximum)
+r,,,Status,Status: System status,,,b509,0d1103,value,,UCH,,,
+r,,,Status01,Status01: Status information 1,,,b509,0d1101,value,,HEX,,,
+r,,,Status02,Status02: Status information 2,,,b509,0d1102,value,,HEX,,,
+r,,,Status16,Status16: Status information 16,,,b509,0d0416,value,,UCH,,,
+r,,,TempGradientFailure,TempGradientFailure: Number of cut offs of the boilers cause of to high gradient (S.54),,,b509,0d1100,value,,UCH,,°C,temperature
+r,,,Currenterror,Current errors,,,b503,0001,error,,UIN,,,error number,error_1,,UIN,,,error number,error_2,,UIN,,,error number,error_3,,UIN,,,error number,error_4,,UIN,,,error number
+r,,,Errorhistory,Error_History,,,b503,0101,index,m,UCH,,,,status,,UCH,,,Status,time,,VTM,,,time,date,,HDA:3,,,date,error,,UIN,,,error number
+w,,install,Clearerrorhistory,Clear error history,,,b503,0201,cleared,s,UCH,0=no;1=yes,,
+r,,,Currentservice,Current service message,,,b503,0002,error,,UIN,,,error number,error_1,,UIN,,,error number,error_2,,UIN,,,error number,error_3,,UIN,,,error number,error_4,,UIN,,,error number
+r,,,Servicehistory,Service message history,,,b503,0102,index,m,UCH,,,,status,,UCH,,,Status,time,,VTM,,,time,date,,HDA:3,,,date,error,,UIN,,,error number
+w,,install,Clearservicehistory,Clear service message history,,,b503,0202,cleared,s,UCH,0=no;1=yes,,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@ebusd/ebus-typespec": ">=0.21.0",
+    "@ebusd/ebus-typespec": "^0.21.0",
     "@typespec/compiler": "~0.64.0",
     "tsx": "^4.19.2"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@ebusd/ebus-typespec": "^0.21.0",
+    "@ebusd/ebus-typespec": ">=0.21.0",
     "@typespec/compiler": "~0.64.0",
     "tsx": "^4.19.2"
   }

--- a/src/vaillant/08.bai.tsp
+++ b/src/vaillant/08.bai.tsp
@@ -19,6 +19,7 @@ import "./bai.308523_inc.tsp";
 import "./bai.0010021901_inc.tsp";
 import "./bai.0010021961_inc.tsp";
 import "./bai.0010008045_inc.tsp";
+import "./bai.0010024646_inc.tsp";
 import "./hcmode_inc.tsp";
 using Ebus;
 using Ebus.Num;
@@ -33,6 +34,9 @@ namespace Bai {
 
   /** included parts */
   union _includes {
+    @condition(Scan.Id.product, "='0010024646'")
+    Scan_Id_product_0010024646: Bai._0010024646_inc,
+
     @condition(Scan.Id.product, "='0010002315'", "'0010002316'", "'0010002317'")
     Scan_Id_product_0010002315: Bai._0010002315_inc,
 

--- a/src/vaillant/bai.0010024646_inc.tsp
+++ b/src/vaillant/bai.0010024646_inc.tsp
@@ -212,11 +212,11 @@ namespace Bai._0010024646_inc {
 
   /** HcPumpStarts: Central heating pump starts */
   @ext(0x56, 0x3)
-  model HcPumpStarts is ReadonlyRegister<cntstarts3>;
+  model HcPumpStarts is ReadonlyRegister<UCH>;
 
   /** HcStarts: Central heating burner starts */
   @ext(0x38, 0x3)
-  model HcStarts is ReadonlyRegister<cntstarts2>;
+  model HcStarts is ReadonlyRegister<UCH>;
 
   /** HwcHours: Hot water operation hours */
   @ext(0x77, 1)
@@ -244,7 +244,7 @@ namespace Bai._0010024646_inc {
 
   /** HcPumpMode: Heating pump mode */
   @ext(0x4e, 0x4)
-  model HcPumpMode is ReadonlyRegister<pumpmode>;
+  model HcPumpMode is ReadonlyRegister<UCH>;
 
   /** Dodane parametry na podstawie wyników komendy grab */
 
@@ -433,20 +433,24 @@ namespace Bai._0010024646_inc {
   model Expertlevel_ReturnTemp is ReadonlyRegister<tempmirrorsensor>;
 
   /** PowerValue: Power value of the boiler */
+  @inherit(r)
   @ext(0xaa, 0)
-  model PowerValue is ReadonlyRegister<HEX:6>;
-
+  model PowerValue {
+      /** Power value of the boiler (minimum and maximum) */
+      @maxLength(6)
+      value: HEX;
+  }
   /** Status: System status */
   @ext(0x11, 0x3)
   model Status is ReadonlyRegister<UCH>;
 
   /** Status01: Status information 1 */
   @ext(0x11, 0x1)
-  model Status01 is ReadonlyRegister<HEX:10>;
+  model Status01 is ReadonlyRegister<HEX>;
 
   /** Status02: Status information 2 */
   @ext(0x11, 0x2)
-  model Status02 is ReadonlyRegister<HEX:7>;
+  model Status02 is ReadonlyRegister<HEX>;
 
   /** Status16: Status information 16 */
   @ext(0x04, 0x16)
@@ -461,4 +465,5 @@ namespace Bai._0010024646_inc {
     Errors_inc,
     Service_inc,
   }
-} 
+}
+

--- a/src/vaillant/bai.0010024646_inc.tsp
+++ b/src/vaillant/bai.0010024646_inc.tsp
@@ -348,6 +348,114 @@ namespace Bai._0010024646_inc {
   @ext(0xde, 0)
   model TimerInputHc is ReadonlyRegister<onoff>;
 
+  /** PrEnergySumHwc1: Energy sum hot water circuit 1 */
+  @ext(0xc5, 0)
+  model PrEnergySumHwc1 is ReadonlyRegister<UIN>;
+
+  /** PrEnergyCountHwc1: Energy count hot water circuit 1 */
+  @ext(0xc6, 0)
+  model PrEnergyCountHwc1 is ReadonlyRegister<UIN>;
+
+  /** PrEnergySumHwc2: Energy sum hot water circuit 2 */
+  @ext(0xc7, 0)
+  model PrEnergySumHwc2 is ReadonlyRegister<UIN>;
+
+  /** PrEnergyCountHwc2: Energy count hot water circuit 2 */
+  @ext(0xc8, 0)
+  model PrEnergyCountHwc2 is ReadonlyRegister<UIN>;
+
+  /** PrEnergySumHwc3: Energy sum hot water circuit 3 */
+  @ext(0xc9, 0)
+  model PrEnergySumHwc3 is ReadonlyRegister<UIN>;
+
+  /** PrEnergyCountHwc3: Energy count hot water circuit 3 */
+  @ext(0xca, 0)
+  model PrEnergyCountHwc3 is ReadonlyRegister<UIN>;
+
+  /** PrEnergySumHc1: Energy sum heating circuit 1 */
+  @ext(0xf5, 0)
+  model PrEnergySumHc1 is ReadonlyRegister<UIN>;
+
+  /** PrEnergyCountHc1: Energy count heating circuit 1 */
+  @ext(0xf6, 0)
+  model PrEnergyCountHc1 is ReadonlyRegister<UIN>;
+
+  /** PrEnergySumHc2: Energy sum heating circuit 2 */
+  @ext(0xf7, 0)
+  model PrEnergySumHc2 is ReadonlyRegister<UIN>;
+
+  /** PrEnergyCountHc2: Energy count heating circuit 2 */
+  @ext(0xf8, 0)
+  model PrEnergyCountHc2 is ReadonlyRegister<UIN>;
+
+  /** PrEnergySumHc3: Energy sum heating circuit 3 */
+  @ext(0xf9, 0)
+  model PrEnergySumHc3 is ReadonlyRegister<UIN>;
+
+  /** PrEnergyCountHc3: Energy count heating circuit 3 */
+  @ext(0xfa, 0)
+  model PrEnergyCountHc3 is ReadonlyRegister<UIN>;
+
+  /** PumpHwcFlowSum: Pump hot water flow sum */
+  @ext(0xc1, 0)
+  model PumpHwcFlowSum is ReadonlyRegister<UIN>;
+
+  /** PumpHwcFlowNumber: Pump hot water flow number */
+  @ext(0xc2, 0)
+  model PumpHwcFlowNumber is ReadonlyRegister<UIN>;
+
+  /** PrAPSCounter: APS counter */
+  @ext(0xf2, 0)
+  model PrAPSCounter is ReadonlyRegister<UCH>;
+
+  /** PrVortexFlowSensorValue: Vortex flow sensor value (legacy name) */
+  @ext(0xf4, 0)
+  model PrVortexFlowSensorValue is ReadonlyRegister<UIN>;
+
+  /** HwcPostrunTime: Hot water pump overrun time */
+  @ext(0x11, 0x4)
+  model HwcPostrunTime is ReadonlyRegister<minutes0>;
+
+  /** ChangesDSN: Numbers adjusting (storing) the DSN */
+  @ext(0x0c, 0)
+  model ChangesDSN is ReadonlyRegister<UCH>;
+
+  /** ExternalFlowTempDesired: External flow temperature desired */
+  @ext(0x25, 0)
+  model ExternalFlowTempDesired is ReadonlyRegister<temp>;
+
+  /** TempMaxDiffExtTFT: Maximum temperature difference */
+  @ext(0x27, 0)
+  model TempMaxDiffExtTFT is ReadonlyRegister<temp>;
+
+  /** Expertlevel_ReturnTemp: Return temperature expert level */
+  @ext(0x6b, 0)
+  model Expertlevel_ReturnTemp is ReadonlyRegister<tempmirrorsensor>;
+
+  /** PowerValue: Power value of the boiler */
+  @ext(0xaa, 0)
+  model PowerValue is ReadonlyRegister<HEX:6>;
+
+  /** Status: System status */
+  @ext(0x11, 0x3)
+  model Status is ReadonlyRegister<UCH>;
+
+  /** Status01: Status information 1 */
+  @ext(0x11, 0x1)
+  model Status01 is ReadonlyRegister<HEX:10>;
+
+  /** Status02: Status information 2 */
+  @ext(0x11, 0x2)
+  model Status02 is ReadonlyRegister<HEX:7>;
+
+  /** Status16: Status information 16 */
+  @ext(0x04, 0x16)
+  model Status16 is ReadonlyRegister<UCH>;
+
+  /** TempGradientFailure: Number of cut offs of the boilers cause of to high gradient (S.54) */
+  @ext(0x11, 0)
+  model TempGradientFailure is ReadonlyRegister<temp0>;
+
   /** included parts */
   union _includes {
     Errors_inc,


### PR DESCRIPTION
This pull request introduces extensive updates to the Vaillant ecoTEC boiler configuration, including new diagnostic parameters, English and German translations, and a new type specification file for structured data modeling. The changes aim to enhance the boiler's diagnostics, data readability, and maintainability.

### Diagnostic and Parameter Additions:
* Added numerous diagnostic parameters for the Vaillant ecoTEC boiler, such as `Statenumber`, `PartloadHcKW`, `WPPostrunTime`, and others, to improve monitoring and troubleshooting capabilities. These include parameters for heating, hot water, pump operations, and safety limits. (`ebusd-2.1.x/de/vaillant/bai.0010024646.inc`, [[1]](diffhunk://#diff-bc9f84fcad142ab01e960f23c2eff541991cd0c30235e4a317df9533494f34c9R1-R60); `ebusd-2.1.x/en/vaillant/bai.0010024646.inc`, [[2]](diffhunk://#diff-b11803db2fc00a5d77c62efb4bab0eefc68120928cab43c035e08855a7f09428R1-R60)

### English and German Translations:
* Introduced English translations for all diagnostic parameters in `ebusd-2.1.x/en/vaillant/bai.0010024646.inc`, ensuring consistency across languages. This includes descriptions for heating part load, pump operations, and flow/return temperatures. (`[ebusd-2.1.x/en/vaillant/bai.0010024646.incR1-R60](diffhunk://#diff-b11803db2fc00a5d77c62efb4bab0eefc68120928cab43c035e08855a7f09428R1-R60)`)

### Type Specification File:
* Created a new type specification file, `src/vaillant/bai.0010024646_inc.tsp`, to define structured models for the boiler's diagnostic parameters. This includes models for flow temperature, ignition attempts, pump modes, and more. The file uses the `ebus-typespec` library for type definitions. (`[src/vaillant/bai.0010024646_inc.tspR1-R356](diffhunk://#diff-178f19a557a8a31a078af494a8ffcd5621d61376406888463418dedc82d14cddR1-R356)`)

### New Parameters in Type Specification:
* Added additional parameters in the type specification file, such as `DisplayMode`, `WaterpressureMeasureCounter`, `HwcTempMax`, and `PumpPowerDesired`, to expand the scope of boiler diagnostics and operations. (`[src/vaillant/bai.0010024646_inc.tspR1-R356](diffhunk://#diff-178f19a557a8a31a078af494a8ffcd5621d61376406888463418dedc82d14cddR1-R356)`)