### PR TITLE
Added "SourceTempInput" for Vaillant HMU (08)

### DIFF
--- a/src/vaillant/08.hmu.tsp
+++ b/src/vaillant/08.hmu.tsp
@@ -209,6 +209,12 @@ namespace Hmu {
   }
 
   @inherit(r_2)
+  @ext(0x22)
+  model SourceTempInput {
+    value: temp;
+  }
+
+  @inherit(r_2)
   @ext(0x27)
   model SourceTempOutput {
     value: temp;


### PR DESCRIPTION
The value was missing in the configuration.
I verified the register on a live system (Vaillant flexoTHERM) by comparing hex dumps with the display values.

- **Reference (SourceTempOutput):**
  - Register: `32 27`
  - Display value: **7.5 °C**
  - Hex value: `0x79` (Decimal 121)
  - Calculation: 121 / 16 = **7.56 °C** (Matches)

- **New Sensor (SourceTempInput):**
  - Register: `32 22`
  - Display value: **7.1 °C**
  - Hex value: `0x74` (Decimal 116)
  - Calculation: 116 / 16 = **7.25 °C** (Matches within tolerance)

The definition uses the same decoder (D2C) as SourceTempOutput.

I hope i did it right in the tsp file. I wrote this 
`r,,,SourceTempInput,Soleeingang,,,b51a,05ff3222,value,,IGN:3,,,,value,,D2C,,°C,`
to my 08.hmu.csv file and this shows me the right Source Temp Input.

