### PR TITLE
adds PartloadHwcKW (d.77) support for eloBLOCK VE 9/14 (models 0010023691, 0010023684 and 0010023657)

### DIFF
--- a/src/vaillant/08.bai.tsp
+++ b/src/vaillant/08.bai.tsp
@@ -20,6 +20,7 @@ import "./bai.0010021901_inc.tsp";
 import "./bai.0010021961_inc.tsp";
 import "./bai.0010043897_inc.tsp";
 import "./bai.0010008045_inc.tsp";
+import "./bai.0010023691_inc.tsp";
 import "./errors_inc.tsp";
 import "./hcmode_inc.tsp";
 using Ebus;
@@ -347,6 +348,9 @@ namespace Bai {
 
     @condition(Scan.Id.product, "='0010008045'", "'0010008863'", "'0010023648'")
     Scan_Id_product_0010008045: Bai._0010008045_inc,
+
+    @condition(Scan.Id.product, "='0010023691'", "'0010023684'", "'0010023657'")
+    Scan_Id_product_0010023691: Bai._0010023691_inc,
 
     @condition(Scan.Id.product, "='0010043897'")
     Scan_Id_product_0010043897: Bai._0010043897_inc,

--- a/src/vaillant/bai.0010023691_inc.tsp
+++ b/src/vaillant/bai.0010023691_inc.tsp
@@ -1,0 +1,16 @@
+import "@ebusd/ebus-typespec";
+import "./_templates.tsp";
+using Ebus;
+using Ebus.Num;
+using Ebus.Dtm;
+using Ebus.Str;
+namespace Vaillant;
+
+namespace Bai._0010023691_inc {
+  // ,BAI00,eloBLOCK VE 9/14
+  // Confirmed working on: 0010023691, 0010023684, 0010023657
+  
+  /** d.77 hot water partload: Storage charging power (1–9 kW) */
+  @ext(0xa9, 0)
+  model PartloadHwcKW is InstallRegister<power>;
+}


### PR DESCRIPTION
adds support for controlling hot water partload (d.77) on Vaillant eloBLOCK VE 9/14 models.

- confirmed models: 0010023691, 0010023684, 0010023657
- confirmed working by @Akeebaby and @AznKid45 (thanks!)
- allows control of storage charging power (1-9 kW)
- discovered through register scanning (diff before/after display changes)

See issue discussion over [here](https://github.com/john30/ebusd-configuration/issues/254#issuecomment-3458475530).

Addresses #254

Thanks for this awesome project! 