### PR TITLE
Update 15.ctlv2.tsp adding GlobalSystemOff and HwcEnabled

### DIFF
--- a/src/vaillant/15.ctlv2.tsp
+++ b/src/vaillant/15.ctlv2.tsp
@@ -41,6 +41,14 @@ namespace Ctlv2 {
     value: hoursum2;
   }
 
+  /** global system OFF */
+  @inherit(r_1, w_1)
+  @ext(0x7, 0)
+  model GlobalSystemOff {
+    /** global system off, disable all schedule and no hc or hwc production */
+    value: yesno;
+  }
+
   /** hwc parallel loading */
   @inherit(r_1, w_1)
   @ext(0xa, 0)
@@ -417,6 +425,14 @@ namespace Ctlv2 {
   @write
   @base(MF, 0x24, 0x2, 1, 1, 0)
   model w_2 {}
+
+  /** HwcEnabled */
+  @inherit(r_2, w_2)
+  @ext(0x1, 0)
+  model HwcEnabled {
+    /** Switch off Hwc production and schedule */
+    value: yesno;
+  }
 
   /** HwcOpMode */
   @inherit(r_2, w_2)


### PR DESCRIPTION
Previously on CSV file I have this 2 entity, that I use on holliday or if I want to stop Hwc production.
So now I add them to tsp new config.

This changes work with Vaillant aroTHERM plus VWL 85/6 A 230V S3