### PR TITLE
fix: rename WaterPressure to WaterPressureEMM in bai.emm_inc.tsp to resolve duplicate name (issue #566)

### DIFF
--- a/src/vaillant/bai.emm_inc.tsp
+++ b/src/vaillant/bai.emm_inc.tsp
@@ -58,7 +58,7 @@ namespace Bai.Emm_inc {
   /** water pressure */
   @inherit(r_1)
   @ext(0x39, 0)
-  model WaterPressure {
+  model WaterPressureEMM {
     /** water pressure */
     value: pressv;
   }


### PR DESCRIPTION
Fixes #566

## Problem
bai.0010043897_inc.tsp includes both bai.308523_inc.tsp and bai.emm_inc.tsp. 
Both templates define a model named WaterPressure, causing a duplicate name 
error in the generated bai.0010043897.inc at line 211.

This causes ebusd to crash when loading the config for any BAI device with 
HW=7603, including BAI00 SW1201 HW7603 (product 0010043922).

## Fix
Rename WaterPressure to WaterPressureEMM in bai.emm_inc.tsp so both 
definitions have unique names.

## Tested on
- BAI00, SW1201, HW7603, product 0010043922
- ebusd 26.1
- LukasGrebe ebusd add-on v26.1.8