### PR TITLE
vaillant: VWZIO Hydraulikstation process telemetry (HW=5103)

### DIFF
--- a/src/vaillant/76.vwz.tsp
+++ b/src/vaillant/76.vwz.tsp
@@ -1,6 +1,7 @@
 import "@ebusd/ebus-typespec";
 import "./_templates.tsp";
 import "./b516_inc.tsp";
+import "./hcmode_inc.tsp";
 using Ebus;
 using Ebus.Num;
 using Ebus.Dtm;
@@ -9,8 +10,11 @@ namespace Vaillant;
 
 // @zz(0x76)
 namespace Vwz {
-  // additions from PR 330 for HMU;0901;5103 / VWZ;0522;5103
-  // Test menus on VWZ. EnableTest message needs to be sent before each of the read messages work.
+  // ----------------------------------------------------------------------
+  // Service tests (existing, unchanged from PR 330)
+  // VWZIO exposes the same 3 service tests as the VWZ; reachable only
+  // after the matching EnableTest* write.
+  // ----------------------------------------------------------------------
 
   /** default *rs for user level "service" */
   @auth("service")
@@ -76,8 +80,146 @@ namespace Vwz {
     dhw: 1,
   }
 
+  // ----------------------------------------------------------------------
+  // Process telemetry (new)
+  //
+  // Reverse-engineered from a 72-h passive grab capture against a
+  // VWZIO HW=5103 / SW=0901 unit acting as the Vaillant
+  // Hydraulikstation between an aroTHERM heat pump (HMU on 0x08) and
+  // the building water circuits. See also issue #315 by @cyberthom42
+  // for parallel decode work on the VWZ MEH 97/6 variant of the same
+  // hydraulic station family.
+  //
+  // The master (0x10) polls these families on slave 0x76; ebusd
+  // subscribes via *u — no active reads are issued.
+  //
+  // DateTime, Status01/02, Status16 and the common SetMode arrive via
+  // the existing Hcmode_inc union below; PowerConsumptionHmu arrives
+  // via B516_inc. Their byte layouts on 0x76 are identical to those
+  // used by the HMU on 0x08.
+  //
+  // Stats01 / Stats02 (b512 0f 00 0X) are VWZIO-specific — no upstream
+  // definition exists. Two D2C water-side temperatures plus an
+  // operating-state enum, with reserved/padding bytes.
+  //
+  // The b51a 05ff32xx slow-poll family (1/h) carries the electric
+  // backup-heater (Heizstab) and 3-way diverter-valve (VUV) counters,
+  // matching @cyberthom42's #315 mapping.
+  // ----------------------------------------------------------------------
+
+  /** default *u for b512 0f00xx family */
+  @passive
+  @base(MF, 0x12, 0xf, 0)
+  model u_b512 {}
+
+  /** Hydraulic-station status — supply temperature + heating-circuit
+   * pressure + modulation/state bytes. Layout per @chrizzzp via
+   * @cyberthom42 issue #315. */
+  @inherit(u_b512)
+  @ext(0x1)
+  model Stats01 {
+    /** UCH off 0 — likely modulation/activity */
+    modulation1: UCH;
+
+    /** UCH off 1 — small enum 2..4 (operating mode?) */
+    mode1: UCH;
+
+    @maxLength(1)
+    ign: IGN;
+
+    /** supply temperature (flow at hydraulic station outlet) */
+    supplytemp: temp;
+
+    /** heating-circuit pressure (UCH / 10 bar) */
+    @unit("bar")
+    @divisor(10)
+    waterpressure: UCH;
+
+    @maxLength(1)
+    ign_1: IGN;
+  }
+
+  /** Alternate poll of the same family — chrizzzp reports it returns
+   * the identical layout as 0f0001 on his split system; on this
+   * HW=5103 the values track a different circuit (likely HC vs HWC). */
+  @inherit(u_b512)
+  @ext(0x2)
+  model Stats02 {
+    /** UCH off 0 */
+    modulation2: UCH;
+
+    /** UCH off 1 */
+    mode2: UCH;
+
+    @maxLength(1)
+    ign: IGN;
+
+    /** supply temperature 2 — r=0.993 with HMU CompressorOutletTemp */
+    supplytemp_2: temp;
+
+    /** pressure (UCH / 10 bar) */
+    @unit("bar")
+    @divisor(10)
+    waterpressure_2: UCH;
+
+    @maxLength(1)
+    ign_1: IGN;
+  }
+
+  // ----------------------------------------------------------------------
+  // Heizstab (electric backup heater) + 3-way valve telemetry.
+  // Slow-polled (1/h). Mapping per @cyberthom42 issue #315.
+  // ----------------------------------------------------------------------
+
+  /** default *u for b51a 05 ff 32 xx (Heizstab statistics) */
+  @passive
+  @base(MF, 0x1a, 0x5, 0xff, 0x32)
+  model u_b51a32 {
+    @maxLength(3)
+    ign: IGN;
+  }
+
+  /** electric backup heater operating hours */
+  @inherit(u_b51a32)
+  @ext(0x46)
+  model ImmersionHeaterHours {
+    @unit("h")
+    value: UIN;
+  }
+
+  /** electric backup heater on/off switch counter */
+  @inherit(u_b51a32)
+  @ext(0x4a)
+  model ImmersionHeaterStarts {
+    value: UIN;
+  }
+
+  /** 3-way diverter-valve heating↔DHW switch counter */
+  @inherit(u_b51a32)
+  @ext(0x4b)
+  model PrioritySwitchingValveOps {
+    value: UIN;
+  }
+
+  /** default *u for b51a 05 ff 33 xx (Heizstab config) */
+  @passive
+  @base(MF, 0x1a, 0x5, 0xff, 0x33)
+  model u_b51a33 {
+    @maxLength(3)
+    ign: IGN;
+  }
+
+  /** configured electric backup heater power cap */
+  @inherit(u_b51a33)
+  @ext(0x1a)
+  model ImmersionHeaterPowerLimit {
+    @unit("kW")
+    value: UIN;
+  }
+
   /** included parts */
   union _includes {
+    Hcmode_inc,
     B516_inc,
   }
 }

--- a/src/vaillant/76.vwz.tsp
+++ b/src/vaillant/76.vwz.tsp
@@ -98,73 +98,70 @@ namespace Vwz {
   // via B516_inc. Their byte layouts on 0x76 are identical to those
   // used by the HMU on 0x08.
   //
-  // Stats01 / Stats02 (b512 0f 00 0X) are VWZIO-specific — no upstream
-  // definition exists. Two D2C water-side temperatures plus an
-  // operating-state enum, with reserved/padding bytes.
+  // StatusDhw (b512 0f, request-content +, slave response) is
+  // VWZIO-specific. Replaces what we'd previously split as
+  // Stats01/Stats02 (id=0f0001 / id=0f0002) — per @Hoppur's PR #598
+  // review (2026-04-30): the bytes after `0f` aren't id-suffix, they
+  // are actual content (StatusCircPump + DhwActive). The same logical
+  // message fires every 10s with whatever current state is. Unifies
+  // the two CSV rows into one and exposes 4 net-new fields
+  // (StatusCircPump, DhwActive, MultifunctionInput, plus correctly
+  // typed HwcStorageTemp / SupplyTemp / WaterPressure / temp_7 pad).
   //
   // The b51a 05ff32xx slow-poll family (1/h) carries the electric
   // backup-heater (Heizstab) and 3-way diverter-valve (VUV) counters,
   // matching @cyberthom42's #315 mapping.
   // ----------------------------------------------------------------------
 
-  /** default *u for b512 0f00xx family */
+  /** default *u for b512 0f family */
   @passive
-  @base(MF, 0x12, 0xf, 0)
+  @base(MF, 0x12, 0xf)
   model u_b512 {}
 
-  /** Hydraulic-station status — supply temperature + heating-circuit
-   * pressure + modulation/state bytes. Layout per @chrizzzp via
-   * @cyberthom42 issue #315. */
+  /** Hydraulikstation DHW state. Layout per @Hoppur's PR #598 review
+   * (2026-04-30). Master sends `b5 12 03 0f <pump-state> <dhw-state>`
+   * every 10 s; slave responds with HWC tank temp + multifunction
+   * input state + supply temp + heating-circuit pressure + 0xff pad.
+   * Verified against this install's 72 h capture: only (pump=0,dhw=1)
+   * and (pump=0,dhw=2) ever seen; MultifunctionInput always 0;
+   * temp_7 always 0xff; HwcStorageTemp range 42-71 °C. */
   @inherit(u_b512)
-  @ext(0x1)
-  model Stats01 {
-    /** UCH off 0 — likely modulation/activity */
-    modulation1: UCH;
+  model StatusDhw {
+    /** master byte 1: circulation pump state */
+    @master
+    @values(Values_StatusCircPump)
+    statuscircpump: UCH;
 
-    /** UCH off 1 — small enum 2..4 (operating mode?) */
-    mode1: UCH;
+    /** master byte 2: DHW heating active */
+    @master
+    @values(Values_DhwActive)
+    dhwactive: UCH;
 
-    @maxLength(1)
-    ign: IGN;
+    /** slave bytes 0+1: DHW tank temperature, D2C 1/16 °C */
+    hwcstoragetemp: temp;
 
-    /** supply temperature (flow at hydraulic station outlet) */
+    /** slave byte 2: multifunction input button state */
+    @values(Values_OnOff)
+    multifunctioninput: UCH;
+
+    /** slave bytes 3+4: supply line temperature D2C 1/16 °C
+     * (sensor reads HC flow when DhwActive=off, compressor outlet
+     * when DhwActive=on — the supply line is physically routed
+     * through the 3-way valve) */
     supplytemp: temp;
 
-    /** heating-circuit pressure (UCH / 10 bar) */
+    /** slave byte 5: heating-circuit pressure UCH/10 bar */
     @unit("bar")
     @divisor(10)
     waterpressure: UCH;
 
-    @maxLength(1)
-    ign_1: IGN;
+    /** slave byte 6: trailing pad, always 0xff in our capture */
+    temp_7: UCH;
   }
 
-  /** Alternate poll of the same family — chrizzzp reports it returns
-   * the identical layout as 0f0001 on his split system; on this
-   * HW=5103 the values track a different circuit (likely HC vs HWC). */
-  @inherit(u_b512)
-  @ext(0x2)
-  model Stats02 {
-    /** UCH off 0 */
-    modulation2: UCH;
-
-    /** UCH off 1 */
-    mode2: UCH;
-
-    @maxLength(1)
-    ign: IGN;
-
-    /** supply temperature 2 — r=0.993 with HMU CompressorOutletTemp */
-    supplytemp_2: temp;
-
-    /** pressure (UCH / 10 bar) */
-    @unit("bar")
-    @divisor(10)
-    waterpressure_2: UCH;
-
-    @maxLength(1)
-    ign_1: IGN;
-  }
+  enum Values_StatusCircPump { off: 0, on: 2 }
+  enum Values_DhwActive { off: 1, on: 2 }
+  enum Values_OnOff { off: 0, on: 1 }
 
   // ----------------------------------------------------------------------
   // Heizstab (electric backup heater) + 3-way valve telemetry.

--- a/src/vaillant/76.vwz.tsp
+++ b/src/vaillant/76.vwz.tsp
@@ -102,10 +102,10 @@ namespace Vwz {
   // VWZIO-specific. Replaces what we'd previously split as
   // Stats01/Stats02 (id=0f0001 / id=0f0002) — per @Hoppur's PR #598
   // review (2026-04-30): the bytes after `0f` aren't id-suffix, they
-  // are actual content (StatusCircPump + DhwActive). The same logical
+  // are actual content (StatusDHWCircPump + DhwActive). The same logical
   // message fires every 10s with whatever current state is. Unifies
   // the two CSV rows into one and exposes 4 net-new fields
-  // (StatusCircPump, DhwActive, MultifunctionInput, plus correctly
+  // (StatusDHWCircPump, DhwActive, MultifunctionInput, plus correctly
   // typed HwcStorageTemp / SupplyTemp / WaterPressure / temp_7 pad).
   //
   // The b51a 05ff32xx slow-poll family (1/h) carries the electric
@@ -118,50 +118,103 @@ namespace Vwz {
   @base(MF, 0x12, 0xf)
   model u_b512 {}
 
-  /** Hydraulikstation DHW state. Layout per @Hoppur's PR #598 review
-   * (2026-04-30). Master sends `b5 12 03 0f <pump-state> <dhw-state>`
-   * every 10 s; slave responds with HWC tank temp + multifunction
-   * input state + supply temp + heating-circuit pressure + 0xff pad.
-   * Verified against this install's 72 h capture: only (pump=0,dhw=1)
-   * and (pump=0,dhw=2) ever seen; MultifunctionInput always 0;
-   * temp_7 always 0xff; HwcStorageTemp range 42-71 °C. */
+  /** Hydraulikstation DHW state per Hoppur PR #598 review */
   @inherit(u_b512)
+  @ext
   model StatusDhw {
-    /** master byte 1: circulation pump state */
-    @master
-    @values(Values_StatusCircPump)
-    statuscircpump: UCH;
+    /** circulation pump state */
+    @out
+    @values(Values_StatusDHWCircPump)
+    statusdhwcircpump: UCH;
 
-    /** master byte 2: DHW heating active */
-    @master
+    /** DHW heating active */
+    @out
     @values(Values_DhwActive)
     dhwactive: UCH;
 
-    /** slave bytes 0+1: DHW tank temperature, D2C 1/16 °C */
+    /** DHW tank temperature */
     hwcstoragetemp: temp;
 
-    /** slave byte 2: multifunction input button state */
+    /** multifunction input button state */
     @values(Values_OnOff)
     multifunctioninput: UCH;
 
-    /** slave bytes 3+4: supply line temperature D2C 1/16 °C
-     * (sensor reads HC flow when DhwActive=off, compressor outlet
-     * when DhwActive=on — the supply line is physically routed
-     * through the 3-way valve) */
+    /** supply line temperature (HC flow if DhwActive=off / compressor outlet if on) */
     supplytemp: temp;
 
-    /** slave byte 5: heating-circuit pressure UCH/10 bar */
+    /** heating-circuit pressure */
     @unit("bar")
     @divisor(10)
     waterpressure: UCH;
 
-    /** slave byte 6: trailing pad, always 0xff in our capture */
+    /** trailing pad always 0xff */
     temp_7: UCH;
   }
 
-  enum Values_StatusCircPump { off: 0, on: 2 }
+  enum Values_StatusDHWCircPump { off: 0, on: 2 }
   enum Values_DhwActive { off: 1, on: 2 }
   enum Values_OnOff { off: 0, on: 1 }
+
+  // ----------------------------------------------------------------------
+  // Display state (b511 07) per @chrizzzp's PR #598 review. Active
+  // read: ebusd polls the slave when the entity is read. Works on
+  // both HMU (0x08) and VWZIO/VWZ00 (0x76); placed here so the VWZ
+  // side gets it (HMU has a simpler `State` already defined in
+  // 08.hmu.tsp covering the first 5 of these 7 bytes).
+  // ----------------------------------------------------------------------
+
+  /** default *r for b511 */
+  @base(MF, 0x11)
+  model r_b511 {}
+
+  /** Hydraulikstation display state per chrizzzp PR #598 review */
+  @inherit(r_b511)
+  @ext(0x7)
+  model Status07 {
+    @unit("%")
+    power: UCH;
+
+    @unit("kWh")
+    @divisor(10)
+    dailyenvyield: UIN;
+
+    display_b0_heaterenabled: BI0;
+    display_b1: BI1;
+    display_b2_backupheater: BI2;
+    display_b3: BI3;
+    display_b4: BI4;
+    display_b5_noisereduction: BI5;
+    display_b6_dhwecomode: BI6;
+    display_b7: BI7;
+
+    @values(Values_Status07HeaterMode)
+    displayheatermain: UCH;
+
+    @unit("bar")
+    @divisor(30)
+    displaysystempressure: UCH;
+
+    @values(Values_Status07HeaterMode)
+    displayheaterbackup: UCH;
+  }
+
+  /** State enum for `Status07.DisplayHeaterMain` and
+   * `Status07.DisplayHeaterBackup`. Two adjacent codes per state
+   * (e.g. 0/1 standby, 8/9 hc) — the low bit appears to subdivide
+   * each mode but isn't documented; preserving both per
+   * @chrizzzp's contribution. */
+  enum Values_Status07HeaterMode {
+    standby_0: 0,
+    standby_1: 1,
+    hc_8: 8,
+    hc_9: 9,
+    error_a: 10,
+    error_b: 11,
+    cool_10: 16,
+    cool_11: 17,
+    dhw_80: 128,
+    dhw_81: 129,
+  }
 
   // ----------------------------------------------------------------------
   // Heizstab (electric backup heater) + 3-way valve telemetry.

--- a/src/vaillant/76.vwz.tsp
+++ b/src/vaillant/76.vwz.tsp
@@ -178,13 +178,21 @@ namespace Vwz {
     @divisor(10)
     dailyenvyield: UIN;
 
+    @values(Values_OnOff)
     display_b0_heaterenabled: BI0;
+    @values(Values_OnOff)
     display_b1: BI1;
+    @values(Values_OnOff)
     display_b2_backupheater: BI2;
+    @values(Values_OnOff)
     display_b3: BI3;
+    @values(Values_OnOff)
     display_b4: BI4;
+    @values(Values_OnOff)
     display_b5_noisereduction: BI5;
+    @values(Values_OnOff)
     display_b6_dhwecomode: BI6;
+    @values(Values_OnOff)
     display_b7: BI7;
 
     @values(Values_Status07HeaterMode)

--- a/src/vaillant/76.vwz.tsp
+++ b/src/vaillant/76.vwz.tsp
@@ -147,82 +147,14 @@ namespace Vwz {
     @divisor(10)
     waterpressure: UCH;
 
-    /** trailing pad always 0xff */
-    temp_7: UCH;
+    /** trailing pad always 0xff in capture */
+    @maxLength(1)
+    ign: IGN;
   }
 
   enum Values_StatusDHWCircPump { off: 0, on: 2 }
   enum Values_DhwActive { off: 1, on: 2 }
   enum Values_OnOff { off: 0, on: 1 }
-
-  // ----------------------------------------------------------------------
-  // Display state (b511 07) per @chrizzzp's PR #598 review. Active
-  // read: ebusd polls the slave when the entity is read. Works on
-  // both HMU (0x08) and VWZIO/VWZ00 (0x76); placed here so the VWZ
-  // side gets it (HMU has a simpler `State` already defined in
-  // 08.hmu.tsp covering the first 5 of these 7 bytes).
-  // ----------------------------------------------------------------------
-
-  /** default *r for b511 */
-  @base(MF, 0x11)
-  model r_b511 {}
-
-  /** Hydraulikstation display state per chrizzzp PR #598 review */
-  @inherit(r_b511)
-  @ext(0x7)
-  model Status07 {
-    @unit("%")
-    power: UCH;
-
-    @unit("kWh")
-    @divisor(10)
-    dailyenvyield: UIN;
-
-    @values(Values_OnOff)
-    display_b0_heaterenabled: BI0;
-    @values(Values_OnOff)
-    display_b1: BI1;
-    @values(Values_OnOff)
-    display_b2_backupheater: BI2;
-    @values(Values_OnOff)
-    display_b3: BI3;
-    @values(Values_OnOff)
-    display_b4: BI4;
-    @values(Values_OnOff)
-    display_b5_noisereduction: BI5;
-    @values(Values_OnOff)
-    display_b6_dhwecomode: BI6;
-    @values(Values_OnOff)
-    display_b7: BI7;
-
-    @values(Values_Status07HeaterMode)
-    displayheatermain: UCH;
-
-    @unit("bar")
-    @divisor(30)
-    displaysystempressure: UCH;
-
-    @values(Values_Status07HeaterMode)
-    displayheaterbackup: UCH;
-  }
-
-  /** State enum for `Status07.DisplayHeaterMain` and
-   * `Status07.DisplayHeaterBackup`. Two adjacent codes per state
-   * (e.g. 0/1 standby, 8/9 hc) — the low bit appears to subdivide
-   * each mode but isn't documented; preserving both per
-   * @chrizzzp's contribution. */
-  enum Values_Status07HeaterMode {
-    standby_0: 0,
-    standby_1: 1,
-    hc_8: 8,
-    hc_9: 9,
-    error_a: 10,
-    error_b: 11,
-    cool_10: 16,
-    cool_11: 17,
-    dhw_80: 128,
-    dhw_81: 129,
-  }
 
   // ----------------------------------------------------------------------
   // Heizstab (electric backup heater) + 3-way valve telemetry.

--- a/src/vaillant/76.vwz.tsp
+++ b/src/vaillant/76.vwz.tsp
@@ -1,6 +1,7 @@
 import "@ebusd/ebus-typespec";
 import "./_templates.tsp";
 import "./b516_inc.tsp";
+import "./hcmode_inc.tsp";
 using Ebus;
 using Ebus.Num;
 using Ebus.Dtm;
@@ -9,8 +10,11 @@ namespace Vaillant;
 
 // @zz(0x76)
 namespace Vwz {
-  // additions from PR 330 for HMU;0901;5103 / VWZ;0522;5103
-  // Test menus on VWZ. EnableTest message needs to be sent before each of the read messages work.
+  // ----------------------------------------------------------------------
+  // Service tests (existing, unchanged from PR 330)
+  // VWZIO exposes the same 3 service tests as the VWZ; reachable only
+  // after the matching EnableTest* write.
+  // ----------------------------------------------------------------------
 
   /** default *rs for user level "service" */
   @auth("service")
@@ -76,8 +80,218 @@ namespace Vwz {
     dhw: 1,
   }
 
+  // ----------------------------------------------------------------------
+  // Process telemetry (new)
+  //
+  // Reverse-engineered from a 72-h passive grab capture against a
+  // VWZIO HW=5103 / SW=0901 unit — a VWZ MEH 97/6 hydraulic station
+  // sitting between an aroTHERM heat pump (HMU on 0x08) and the
+  // building water circuits. See also issue #315 by @cyberthom42 for
+  // parallel decode work on the same station, and the PR #598
+  // discussion for an independent live-verified confirmation of the
+  // Status01 layout on a second VWZ MEH 97/6 (SW=0902) by
+  // @meierchen006.
+  //
+  // The master (0x10) polls these families on slave 0x76; ebusd
+  // subscribes via *u — no active reads are issued.
+  //
+  // DateTime, Status01/02, Status16 and the common SetMode arrive via
+  // the existing Hcmode_inc union below; PowerConsumptionHmu arrives
+  // via B516_inc. Their byte layouts on 0x76 are identical to those
+  // used by the HMU on 0x08.
+  //
+  // Sensor positions for Status01 on this station (Vaillant manual
+  // 0020291526, annex A "Funktionsschema" + annex C
+  // "Reglerleiterplatte"): the flow temp is the sensor at the outlet
+  // of the electric backup heater (annex A item 2, on X22 as
+  // "Vorlauftemperaturfühler Heizstab") — it reads ~1 K above the
+  // HMU flow sensor, more when the backup heater contributes. The
+  // storage temp is the DHW cylinder sensor on X22 ("Temperatursensor
+  // Warmwasserspeicher"), matching the lower cylinder sensor per
+  // @meierchen006. Polled every few seconds by the master (~6/min
+  // here, ~1/s reported by @meierchen006), Status01 is the fastest
+  // passive flow/storage temperature source on the bus.
+  //
+  // StatusDhw (b512 0f, request-content +, slave response) is
+  // VWZIO-specific. Replaces what we'd previously split as
+  // Stats01/Stats02 (id=0f0001 / id=0f0002) — per @Hoppur's PR #598
+  // review (2026-04-30): the bytes after `0f` aren't id-suffix, they
+  // are actual content (PumpMode + DhwActive). The same logical
+  // message fires every 10s with whatever current state is. Unifies
+  // the two CSV rows into one and exposes 4 net-new fields
+  // (PumpMode, DhwActive, MultifunctionInput, plus correctly
+  // typed HwcStorageTemp / SupplyTemp / WaterPressure / temp_7 pad).
+  //
+  // PumpMode (byte 1) is a three-valued consumer selector, not an
+  // on/off flag, and no single installation exercises all of it. Both
+  // it and DhwActive sit in the MASTER part of the request, so this is
+  // the controller telling the station what to serve, not the station
+  // reporting a pump.
+  //
+  //   0  no consumer selected
+  //   1  cooling      -- measured on a CTLV2 (sensoCOMFORT 720) install
+  //   2  circulation  -- measured by @niltrip on a VRC700 install
+  //
+  // 2 = circulation: on VWZIO HW=5103/SW=0901 with a VRC700, @niltrip
+  // correlated the byte with the physical DHW circulation pump across a
+  // configured circulation time window, cross-checked against
+  // hmu StatusCirPump (b512 00), which the VRC700 writes as 100/0 at the
+  // same instants. Reproducible over the window; DhwActive stays off
+  // throughout. That install has never emitted 1.
+  //
+  // 1 = cooling: on the CTLV2 install the byte runs only while the
+  // machine cools, and that install has never emitted 2. 15 days of
+  // decoded state changes (2026-08-29..09-13, 144 transitions): 12
+  // episodes at 1, all inside the cooling period that ended 2026-09-01,
+  // none in the twelve days since. Against the HMU's own cooling flag
+  // (Status07 heatermain_b4_cooling, sampled 2-minutely) the byte
+  // ENVELOPES the compressor cycles rather than following them -- up to
+  // 30 min ahead of a cooling block, ~1-3 min after it (overrun),
+  // bridging the pauses between cycles: it held 1 continuously
+  // 08-30 13:37->19:30 while the cooling flag was false for 58 min
+  // inside that span. The last fall, 09-01 00:03:03, trails the last
+  // cooling sample (00:00:01) by 3 min. An earlier 18.5 h raw-log
+  // timeline against Mc1Operation (b523 0200) on the VR 71 shows the
+  // same shape at telegram resolution:
+  //
+  //   pumpmode  19:28:38 ->1  21:51:08 ->0  22:19:37 ->1  04:03:08 ->0
+  //   Mc1 cool  19:28:40 ->2  21:48:10 ->0  22:19:38 ->2  04:00:11 ->0
+  //
+  // Neither value mirrors hmu StatusCirPump. On the CTLV2 install that
+  // message is a constant on, written every 5 min (193/193 telegrams in
+  // the container log) while PumpMode sits at 0, and MultiRelaySetting
+  // there reads unknown rather than circulation -- no circulation is
+  // configured at all. So 0 means "no consumer selected", not
+  // "circulation inactive", and on an install without a circulation
+  // pump the 2 simply never occurs.
+  //
+  // It is specifically NOT the shared heating/underfloor circuit pump,
+  // which is the obvious candidate since that pump normally serves both
+  // modes. Control test on the 72 h reference capture: Mc1 ran in
+  // heating (status=01) with its own pump byte at 01 across all 3451
+  // response variants, while this byte held a constant 00 throughout.
+  //
+  // History, because this field has now been wrong twice the same way:
+  // 2=on was first derived by analogy with DhwActive from a capture in
+  // which the byte never left 00 (only masters ...0f0001 / ...0f0002
+  // appear there), then corrected to 1=on once 1 appeared -- right about
+  // 1, wrong to conclude that 2 did not exist, since it had merely never
+  // been exercised on that install. An installation exercises its own
+  // configuration, not the protocol's alphabet. Each value above is
+  // named from a measurement on the install that produced it; 3 and
+  // above stay unnamed. The field was called StatusDHWCircPump until
+  // 2026-09-13; that name asserted the DHW-circulation reading of 2 for
+  // every value and was simply wrong for 1, so it is renamed rather than
+  // kept for compatibility.
+  //
+  // DhwActive additionally emits 0, which is not a duration state: it
+  // appears for exactly one 10 s cycle and is always bracketed by off
+  // (off -> 0 -> off, 4 valid occurrences in 18.5 h), never adjacent to
+  // on. Mapped as `idle` to describe the observation without claiming a
+  // meaning for it.
+  //
+  // The b51a 05ff32xx slow-poll family (1/h) carries the electric
+  // backup-heater (Heizstab) and 3-way diverter-valve (VUV) counters,
+  // matching @cyberthom42's #315 mapping.
+  // ----------------------------------------------------------------------
+
+  /** default *u for b512 0f family */
+  @passive
+  @base(MF, 0x12, 0xf)
+  model u_b512 {}
+
+  /** Hydraulikstation DHW state per Hoppur PR #598 review */
+  @inherit(u_b512)
+  @ext
+  model StatusDhw {
+    /** selected consumer: off / cooling / DHW circulation */
+    @out
+    @values(Values_PumpMode)
+    pumpmode: UCH;
+
+    /** DHW heating active */
+    @out
+    @values(Values_DhwActive)
+    dhwactive: UCH;
+
+    /** DHW tank temperature */
+    hwcstoragetemp: temp;
+
+    /** multifunction input button state */
+    @values(Values_OnOff)
+    multifunctioninput: UCH;
+
+    /** supply line temperature (HC flow if DhwActive=off / compressor outlet if on) */
+    supplytemp: temp;
+
+    /** heating-circuit pressure */
+    @unit("bar")
+    @divisor(10)
+    waterpressure: UCH;
+
+    /** trailing pad always 0xff in capture */
+    @maxLength(1)
+    ign: IGN;
+  }
+
+  enum Values_DhwActive { idle: 0, off: 1, on: 2 }
+  enum Values_PumpMode { off: 0, cooling: 1, circulation: 2 }
+  enum Values_OnOff { off: 0, on: 1 }
+
+  // ----------------------------------------------------------------------
+  // Heizstab (electric backup heater) + 3-way valve telemetry.
+  // Slow-polled (1/h). Mapping per @cyberthom42 issue #315.
+  // ----------------------------------------------------------------------
+
+  /** default *u for b51a 05 ff 32 xx (Heizstab statistics) */
+  @passive
+  @base(MF, 0x1a, 0x5, 0xff, 0x32)
+  model u_b51a32 {
+    @maxLength(3)
+    ign: IGN;
+  }
+
+  /** electric backup heater operating hours */
+  @inherit(u_b51a32)
+  @ext(0x46)
+  model ImmersionHeaterHours {
+    @unit("h")
+    value: UIN;
+  }
+
+  /** electric backup heater on/off switch counter */
+  @inherit(u_b51a32)
+  @ext(0x4a)
+  model ImmersionHeaterStarts {
+    value: UIN;
+  }
+
+  /** 3-way diverter-valve heating↔DHW switch counter */
+  @inherit(u_b51a32)
+  @ext(0x4b)
+  model PrioritySwitchingValveOps {
+    value: UIN;
+  }
+
+  /** default *u for b51a 05 ff 33 xx (Heizstab config) */
+  @passive
+  @base(MF, 0x1a, 0x5, 0xff, 0x33)
+  model u_b51a33 {
+    @maxLength(3)
+    ign: IGN;
+  }
+
+  /** configured electric backup heater power cap */
+  @inherit(u_b51a33)
+  @ext(0x1a)
+  model ImmersionHeaterPowerLimit {
+    @unit("kW")
+    value: UIN;
+  }
+
   /** included parts */
   union _includes {
+    Hcmode_inc,
     B516_inc,
   }
 }


### PR DESCRIPTION
# PR draft — vaillant: process telemetry for VWZIO Hydraulikstation HW=5103 (slave 0x76)

## Summary

The current `src/vaillant/76.vwzio.tsp` only exposes three service-level
test messages (`b514 05*`). The VWZIO is the **Vaillant
Hydraulikstation** that sits between the aroTHERM heat pump(s) and the
building water circuits; on this install the heat-pump side is the HMU
on 0x08.

This PR builds on prior community work that never landed upstream:

- [#315](https://github.com/john30/ebusd-configuration/issues/315)
  (open) by @cyberthom42 — VWZ MEH 97/6 decode (German names),
  parallel hardware variant of the same family.
- [#407](https://github.com/john30/ebusd-configuration/pull/407)
  (closed) by @chrizzzp — comprehensive 76.vwz.csv covering Heizstab
  counters, b514 Test-mode telemetry, English naming. We adopt
  @chrizzzp's English names where ranges overlap.
- The `b512 0f 00 0X` 7-byte payload layout is per the wiki page on
  [@cyberthom42's vaillant-arotherm-plus](https://github.com/cyberthom42/vaillant-arotherm-plus/wiki/Anbindung-ebus)
  (originally posted by @chrizzzp) — verified byte-for-byte against
  our 72-h capture.
- [#490](https://github.com/john30/ebusd-configuration/issues/490)
  (open) + [#504](https://github.com/john30/ebusd-configuration/pull/504)
  by @filippz — b516 energy-statistics framework. Already pulled into
  upstream `b516_inc.tsp` which we reuse via the existing `_includes`
  union.

This PR is intentionally narrower than #407: only the messages the
master polls passively on a `HW=5103;SW=0901` system are added, all
in `*u` direction (no active reads = no extra bus traffic). The
larger b514 Test-mode family from #407 is left for a follow-up PR
because it requires `r` direction and changes bus behaviour.

On a `HW=5103;SW=0901` unit, the master (0x10) regularly polls
additional process-data and counter telegrams on slave 0x76:

| PB SB | ID         | Cycle  | Bytes | Upstream pattern? |
|-------|------------|-------:|------:|---|
| `b504`| `00`       | ~1/min |    10 | yes — `Hcmode_inc.DateTime` |
| `b511`| `01`       | ~6/min |     9 | yes — `Hcmode_inc.Status01` |
| `b511`| `02`       | (idle) |     8 | yes — `Hcmode_inc.Status02` |
| `b512`| `0f 00 01` | ~5/min |     7 | **new** — water-side `Stats01` |
| `b512`| `0f 00 02` | ~1/min |     7 | **new** — water-side `Stats02` |
| `b516`| `14`       | ~1/min |     5 | yes — `B516_inc.PowerConsumptionHmu` (likely Heizstab on this unit) |
| `b51a`| `05 ff 32 46` | 1/h |    10 | **new** — `ImmersionHeaterHours` (#315/#407) |
| `b51a`| `05 ff 32 4a` | 1/h |    10 | **new** — `ImmersionHeaterStarts` (#315/#407) |
| `b51a`| `05 ff 32 4b` | 1/h |    10 | **new** — `PrioritySwitchingValveOps` (#315/#407) |
| `b51a`| `05 ff 33 1a` | 1/h |    10 | **new** — `ImmersionHeaterPowerLimit` (#407) |

This PR

1. Wires `Hcmode_inc` and (via the existing union) `B516_inc` into the
   `Vwz` namespace's `_includes`, so the four upstream-defined messages
   (`DateTime`, `Status01`, `Status02`, `PowerConsumptionHmu`) become
   visible on 0x76 with byte-identical layouts to the HMU master.
2. Adds two VWZIO-specific models, `Stats01` and `Stats02`, for the
   `b512 0f 00 0X` family.

No changes to the existing service-test messages; no `r`/`w` direction
is introduced for the new families (everything is `*u`/passive).

## Methodology

72 hours of passive bus capture using the upstream `john30/ebusd`
container (v26.1) on host:

```
docker exec ebusd ebusctl grab        # enable grab
# every 60 s for 72 h:
docker exec ebusd ebusctl grab result all >> capture.log
```

Output: 4313 hourly snapshots, 8.99 M telegram observations, 137
distinct `(zz=0x76, pb, sb, id)` tuples. Per-byte statistics
(`nunique`, `entropy`, `0xff_ratio`, `byte_min/max`, monotonicity) were
computed across the histogram of distinct response payloads, weighted by
ebusd's grab counter. Decoder selection used physical plausibility
(temperature range, monotonic counters, BCD shape) plus cross-validation
against simultaneous HMU telegrams in the same capture.

Tooling and full per-message report:
[https://github.com/<user>/ebusd-vwzio-reverseeng](https://github.com/<user>/ebusd-vwzio-reverseeng)
(see `analysis/per_message/*.md`, `analysis/hypotheses.csv`,
`analysis/hmu_correlation.csv`).

## Per-family evidence

### `b504 00` — `DateTime` (reuses `Hcmode_inc.DateTime`)

```
sample request : 1076b5040100
sample response: 0344462227040126d20b
                 dcfstate=03 valid
                 btime=44 46 22  → 22:46:44 BCD ✓
                 bdate=27 04 01 26 → 27 Apr 2026, dow=1 ✓
                 temp =d2 0b      → D2B/256 = 0x0bd2/256 = +11.82 °C
distinct over 72 h: 4211
field n_distinct=2604..4211 across all 8 active bytes; 0xff_ratio=0.06.
```

### `b511 01` — `Status01` (reuses `Hcmode_inc.Status01`)

```
sample response: 5cffc50bff610000ff
                 temp     = 5c   D1C → 46 °C  (flow)
                 temp_1   = ff   D1C → no data (return temp not present)
                 temp_2   = c50b D2B → +11.77 °C (outside)
                 temp_3   = ff   D1C → no data (DHW not present)
                 temp_4   = 61   D1C → 48.5 °C (storage)
                 pumpstate= 00 → off
trailing 2 bytes: 00 ff (implicit IGN; 9-byte response)
distinct: 2604; max grab count: 25813 (≈6/min).
```

**Update (2026-06-10):** @meierchen006 independently decoded this message on a
second VWZ MEH 97/6 (VWZIO SW=0902) and live-verified it against the controller
display over a full DHW charge run — layout confirmed byte for byte (see comment
below). Sensor positions per the official Vaillant manual 0020291526 (annex A
"Funktionsschema" item 2, annex C "Reglerleiterplatte" X22): flow temp = sensor at
the **outlet of the electric backup heater** (reads ~1 K above the HMU flow sensor,
more when the immersion heater contributes); storage temp = **DHW cylinder sensor**
(matches the lower cylinder sensor). Practical note: the poll rate is
config-dependent — ~10 s here (sensoCOMFORT 720 / CTLV2, plus a Vaillant network
gateway: `MF=Vaillant;ID=NETX3;SW=0129;HW=0404` at slave `0xf6` / master `0xf1`)
and ~10 s on @chrizzzp's VR921 system, with ~1/s reported on @meierchen006's VR921
setup (cause unconfirmed; two independent gateway-equipped systems both land at
~10 s, so the gateway alone doesn't account for the difference). *Correction:* an
earlier revision of this description and of the comment thread below described this
system as having "no internet gateway" / "no VR921" — that was wrong, the NETX3
above is exactly such a gateway. The conclusion is unaffected, since it now rests
on @chrizzzp's and @meierchen006's two VR921 systems differing from each other.
Either way `Status01` is the fastest passive flow/storage temperature source on the bus — the `b509`
counterparts refresh only about once per minute. Documented in the TSP comment
block in `0fb519b`/`6fe5d04`.

### `b511 02` — `Status02` (reuses `Hcmode_inc.Status02`)

Polled only when the heat pump is actively heating; observed in our
capture window only briefly, byte layout matches HMU `Status02`
verbatim.

### `b512 0f 00 01` — `Stats01` (NEW)

7-byte response. 2850 distinct payloads, max grab count 21530 (≈5/min).
Layout (per @chrizzzp via @cyberthom42 issue #315):

```
off | n_unique | byte_min | byte_max | type      | meaning
----+---------+-----------+-----------+----------+----------------------
  0 |   209   |   0x00    |   0xff    | UCH       | modulation/activity
  1 |     3   |   0x02    |   0x04    | UCH       | mode (2..4)
  2 |     1   |   0x00    |   0x00    | IGN       | reserved
  3 |   256   |   0x00    |   0xff    | D2C low   | supply temperature
  4 |     3   |   0x02    |   0x04    | D2C high  |   (cont.)
  5 |     6   |   0x09    |   0x0e    | UCH/10    | water pressure (bar)
  6 |     1   |   0xff    |   0xff    | IGN       | trailing pad
```

Decoded ranges over 72 h:

```
modulation1   (UCH):     0..255    (likely compressor activity %)
mode1         (UCH):     2..4      (likely operating mode enum)
supplytemp    (D2C/16):  ~32..80 °C
waterpressure (UCH/10):  ~0.9..1.4 bar
```

Live readings (a representative snapshot on the contributing system):

```
modulation1=28  mode1=3  supplytemp=51.75 °C  waterpressure=1.3 bar
```

Plausibility: 1.3 bar matches the typical heating-circuit static
pressure for a residential floor-heating system; 50 °C supply temp is
in the expected range for an HC flow temp; the modulation byte tracks
the HMU compressor activity over time.

### `b512 0f 00 02` — `Stats02` (NEW)

Same byte layout as `Stats01`. 714 distinct payloads, max grab count
4293 (≈1/min). On @chrizzzp's split system this register returns the
identical answer as `0f 00 01`; on this HW=5103 the temperatures and
pressures track a *different* circuit (likely HC vs HWC primary side
of the dual-mode hydraulic station).

Decoded ranges over 72 h:

```
supplytemp_2    (D2C/16):  ~22..76 °C
waterpressure_2 (UCH/10):  ~0.4..1.4 bar (lower than Stats01)
```

Cross-validation: VWZIO `Stats02.supplytemp_2` Pearson-correlates with
HMU `RunDataCompressorOutletTemp` at *r* = 0.993 with identical
decoded range (46.62 °C). Likely reflects thermal coupling across the
primary heat exchanger (water side ↔ refrigerant side) rather than a
common physical sensor.

### `b516 14` — `PowerConsumptionHmu` (reuses `B516_inc.PowerConsumptionHmu`)

5-byte response (1 IGN + 4 EXP /1000 kW). Polled ~1/min, monotonic
under sustained heat-pump operation in our 72 h window. Live values on
a standby unit: 0.003 kW (3 W), consistent with HMU's
`PowerConsumptionHmu` reading 0.0065 kW at the same time.

## Validation

- `npx tsp compile --emit @ebusd/ebus-typespec --warn-as-error` exits 0
  on this branch.
- The compiled CSV passes `ebusd --checkconfig --configpath=...` exit 0.
- Live deploy on the contributing system: `ebusd 26.1` on a real bus,
  `--scanconfig --configpath=/etc/ebusd`, all five new messages decode
  to physically plausible values and sustain over 24+ hours. MQTT
  discovery via `mqtt-hassio.cfg` produces 12 sensor entities under
  device `ebusd vwzio`, all picked up by Home Assistant.
- HMU master continues to operate normally throughout — passive
  definitions only, no extra bus traffic from ebusd.

## Hardware identification

```
ebusctl info
  address 76: slave #9, scanned
    "MF=Vaillant;ID=VWZIO;SW=0901;HW=5103",
    loaded "vaillant/76.vwzio.csv"
```

Installation context: this Hydraulikstation is fed by a **cascade of two
`aroTHERM plus VWL 75/6 A S2`**. Only unit #1 is on the bus, as the HMU
on 0x08 (also HW=5103, SW=0902); unit #2 sits behind a VR 32 B bus
coupler on 0x18 and answers only its own master, so it contributes
nothing to the captures below. Service tests already in upstream
were originally added for VWZ 0522;5103 in PR #330; HW=5103 / SW=0901
adds the process-telemetry families above without affecting the VWZ
service-test reads.

## Out of scope / not in this PR

- **Active reads (r-direction)**: this PR is `*u`-only by design. The
  master polls these messages on its own; we only listen. @chrizzzp's
  #407 added a much larger r-direction set including the b514 Test-mode
  family (`SupplyTemp`, `ReturnTemp`, `BuildingCircuitWaterPressure`,
  `BuildingCircuitFlow`, `OutdoorTemp`, `CompressorOutletTemp`, …) —
  worth a separate PR after community review.
- **Additional `b51a 05ff32xx` slow-poll registers (controller-, hardware-
  and config-dependent)**: which of these the master polls is
  controller-specific. Our sensoCOMFORT 720 polls `05ff3240` (only ever
  `02 ff 01` here) and `05ff324d` (returns data), but never requests
  `05ff3249`/`324c`/`325c` at all. A `02 ff 01` reply means **"no data for
  this register right now"**, not "register absent" — and the scope depends
  on the ID: *transient* on registers that normally carry data (even
  `ImmersionHeaterHours` (`3246`), which decodes fine to 84 h here, returns
  it on a fraction of polls), but *permanent / system-dependent* on
  registers a given hardware or configuration never populates. @meierchen006
  confirmed the latter on an air/water monobloc (CTLV3): a set of config
  registers (e.g. `SourceTempOutput` — no brine source on a monobloc — plus
  the heat-curve / bivalence / setpoint IDs) answer `02 ff 01`
  *continuously, even with the compressor running*. So `02 ff 01` reads as
  "no data available", with the cause (transient vs configuration) varying
  by register, rather than a flat "intermittent". Two of these
  registers decode cleanly (same `IGN:3`+
  `UIN` template), confirmed on **two independent units** via active read —
  @meierchen006's VWZIO (SW=0902) and ours (SW=0901):
  - `b51a 05ff3249` `TotalEnergyImmersionHeater` (kWh) — 99 kWh (his) /
    **557 kWh** (ours). Read at the same moment, the VWZIO's `b516`
    `StatElectricEnergySum` gives **557.003 kWh** — identical to the kWh, so
    these are the *same counter in two encodings* rather than merely
    consistent values. (An earlier revision of this description quoted
    483 vs 442 kWh and called that "consistent"; the 41 kWh gap was simply
    the two figures being read at different times, not a scaling
    difference.) Immersion-heater hours are 101 h here.
  - `b51a 05ff324c` `ImmersionHeaterPower` (W) — 0 W idle on both
    (byte-identical reply `0aff083500000000000000`); scaling unconfirmed
    until caught while the heater runs.
  They belong in `r` (active read) rather than `*u`, since not every
  controller polls them — so they stay **out of this passive-only PR** and
  are documented here as easy local `r` additions (or a follow-up PR) for
  MEH owners whose backup heater is fitted/used. The remaining IDs
  (`3240`/`325c` + `#407`'s `TotalRunningHours` / `ImmersionHeaterTemp` /
  `FlowPressure`) are still open.
- **Per-bit decoding of `mode1`/`mode2` (small UCH enum 2..4)**:
  correlates loosely with HMU `RunDataStatuscode` transitions but not
  1:1; treating as raw UCH.
- **`b504 0100` off 8-9** is decoded as `temp` D2B identically to the
  HMU's `DateTime.temp`. On this VWZIO unit the reading equals
  `Status01.temp_2` at the same instant; both come through
  `Hcmode_inc` so no extra change needed.

## Note on the `b51a` `05ff…` prefix and reply layout

The `05ff` that prefixes every `b51a` register ID in this description (and in
the `r` definitions circulating in #407 / #315) is **not part of the register
address**. The first data byte is a sub-command and the second a sequence
counter:

```
read    b51a NN=04   05 <seq> <reg-hi> <reg-lo>
write   b51a NN=06   06 <seq> <reg-hi> <reg-lo> <value u16 LE>
```

So `05ff3249` is "read, sequence `ff`, register `3249`". Any sequence byte
works: in a raw bus capture here the HMU master reads one and the same
register with `05 6c`, `05 74`, `05 a0`, `05 c5`, `05 fa`, `05 09` and `05 13`
and gets byte-identical answers. The write form was observed live when the
VWZ hydraulic station (master `71`) sent `06 0c 331b 0100` to the HMU at the
moment a configuration parameter was changed at the inner unit's display.

A populated register answers with 10 data bytes, and **the second byte tells
you which of two shapes you are looking at**:

```
ff 08 TT | value u16 LE | 00 00 00 00 00 00        measured value / counter
ff 02 TT | value u16 LE | min u16 LE | max u16 LE | 01    configuration parameter
```

Read side by side on this installation:

```
05ff3249  TotalEnergyImmersionHeater   0aff08262d020000000000   557    (type 08)
05ff3246  ImmersionHeaterHours         0aff082765000000000000   101 h  (type 08)
05ff324c  ImmersionHeaterPower         0aff083500000000000000     0    (type 08)
05ff331a  ImmersionHeaterPowerLimit    0aff021506000000090001   6 / 0 / 9  (type 02)
```

So the `IGN:3` + `UIN` template is exactly right for the `08` registers this PR
discusses — the trailing bytes really are padding there. For `02` registers it
discards the limits: `ImmersionHeaterPowerLimit` (`331a`) reads value 6 /
minimum 0 / **maximum 9**, and 9 kW is precisely the backup-heater rating
encoded in the type designation VWZ MEH **97**/6 ("9 = 9 kW Zusatzheizung",
manual 0020291526 ch. 3.5) — an independent check on the layout. Nothing is
proposed to change here, since this PR is passive-only; it is noted so anyone
adding `r` definitions knows what the trailing bytes mean.

## Files changed

- `src/vaillant/76.vwzio.tsp` — service-test block kept verbatim;
  `Stats01`, `Stats02`, `u_b512` default added; `_includes` extended
  with `Hcmode_inc`.

No changes to `_templates.tsp`, `hcmode_inc.tsp`, `b516_inc.tsp` or any
other shared file.

---

*Edited 2026-09-13: corrected the installation-context paragraph. It
previously read "VWZIO is the second of two aroTHERM units" — the VWZIO
is the Hydraulikstation, not one of the heat pumps. No change to the
proposed definitions or to any capture.*
