### PR TITLE
vaillant: add RunDataFlowTemp + RunDataReturnTemp to 08.hmu.HW5103

### DIFF
--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -385,6 +385,20 @@ namespace Hmu_HW5103 {
     value: tempv;
   }
 
+  @inherit(r_7)
+  @ext(0xfc, 0x8)
+  model RunDataFlowTemp {
+    /** current flow temp, accurate to 2 decimal places */
+    value: tempv;
+  }
+
+  @inherit(r_7)
+  @ext(0x6, 0x9)
+  model RunDataReturnTemp {
+    /** current return temp, accurate to 2 decimal places */
+    value: tempv;
+  }
+
   // B516
   /** default *r */
   @base(MF, 0x16)


### PR DESCRIPTION
## Summary

PR #496 (merged 2025-04-12) added `RunDataFlowTemp` and `RunDataReturnTemp` to `src/vaillant/08.hmu.tsp`. The HW=5103 firmware variant has its own file (`08.hmu.HW5103.tsp`) that does not import from `08.hmu.tsp`, so HW=5103 owners — explicitly the hardware @roe-lz called out in #446 ("These work on `MF=Vaillant;ID=HMU00;SW=0902;HW=5103`") — never received the new entities.

This adds the two models to `08.hmu.HW5103.tsp` so the same telemetry is available on HW=5103 systems.

## Live verification (`HW=5103;SW=0902`)

```
RunDataFlowTemp   = 31.29 °C
RunDataReturnTemp = 31.05 °C
```

Both consistent with the existing `flowtemp` / `status01_temp` + `status01_temp_1` readings within sensor tolerance, but at higher precision because `tempv` is `EXP` rather than `D1C`.

## Build

- `npx tsp compile --emit @ebusd/ebus-typespec --warn-as-error` exits 0
- `ebusd --checkconfig` with the compiled CSV exits 0

## Diff

```diff
   @inherit(r_7)
   @ext(0xde, 0x8)
   model RunDataAirInletTemp {
     value: tempv;
   }

+  @inherit(r_7)
+  @ext(0xfc, 0x8)
+  model RunDataFlowTemp {
+    /** current flow temp, accurate to 2 decimal places */
+    value: tempv;
+  }
+
+  @inherit(r_7)
+  @ext(0x6, 0x9)
+  model RunDataReturnTemp {
+    /** current return temp, accurate to 2 decimal places */
+    value: tempv;
+  }
+
   // B516
```

Same `r_7` base, same `tempv` type, same `@ext` bytes as the generic `08.hmu.tsp`.