### PR TITLE
add SilentModeCompressorReduction for hmu HW5103

### DIFF
--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -188,7 +188,7 @@ namespace Hmu_HW5103 {
   @inherit(r_silent, w_silent)
   @ext(0xff, 0x34, 0x28)
   @Ebus.example("40%", "3108b51a0405ff3428", "0aff021b280028003c0001")
-  model SilentModeReductionFactor {
+  model SilentModeCompressorReduction {
     @minValue(30)
     @maxValue(60)
     value: percent0;

--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -175,6 +175,25 @@ namespace Hmu_HW5103 {
     value: percent;
   }
 
+  @base(MF, 0x1a, 0x5)
+  model r_silent {
+    @maxLength(3)
+    ign: IGN;
+  }
+
+  @write
+  @base(MF, 0x1a, 0x6)
+  model w_silent {}
+
+  @inherit(r_silent, w_silent)
+  @ext(0xff, 0x34, 0x28)
+  @Ebus.example("40%", "3108b51a0405ff3428", "0aff021b280028003c0001")
+  model SilentModeReductionFactor {
+    @minValue(30)
+    @maxValue(60)
+    value: percent0;
+  }
+
   @inherit(r_2)
   @ext(0x2A)
   model YieldCoolingMonth {


### PR DESCRIPTION
With the recent addition of `SilentTimer_*` I was missing the ability to set the compressor reduction used in silent mode. So here it is.

## Summary
- add `SilentModeCompressorReduction` for `08.hmu.HW5103` using the HMU B51A read/write commands `05ff3428` and `06ff3428`
- expose the field as `percent0` with a 30-60% range

## Validation
- compiled `src/vaillant/08.hmu.HW5103.tsp` with `@ebusd/ebus-typespec` and `withMinMax=true`
- compiled full `src/main.tsp` with `@ebusd/ebus-typespec`
- verified on a live micro-ebusd adapter that the read command returns the configured value and a write of a new value within the range is accepted

## Notes
- this follows the compressor silent operation B51A pattern discussed in #475