### PR TITLE
add base config values from vwzio menu

### DIFF
--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -379,11 +379,13 @@ namespace Hmu_HW5103 {
     uch: UCH;
   }
 
-  /** maximum anti-cycling time */
+  /** maximum block time by energy company (S21 contact) */
   @inherit(r_3, wi_1)
   @ext(0x34, 0x2d)
-  model MaxAntiCyclingTime {
-    value: integral;
+  model MaximumS21BlockAllowed {
+    @minValue(0)
+    @maxValue(9)
+    value: hour;
   }
 
   /** pump speed for heating */
@@ -392,7 +394,9 @@ namespace Hmu_HW5103 {
   model BuildingCircuitPumpOutputHeating {
     /** pump percentage or auto */
     @values(Values_pumpperc)
-    value: percentp;
+    @minValue(49)
+    @maxValue(100)
+    value: percent2;
   }
 
   /** pump speed for cooling */
@@ -401,7 +405,9 @@ namespace Hmu_HW5103 {
   model BuildingCircuitPumpOutputCooling {
     /** pump percentage or auto */
     @values(Values_pumpperc)
-    value: percentp;
+    @minValue(49)
+    @maxValue(100)
+    value: percent2;
   }
 
   /** pump speed for domestic hot water */
@@ -410,32 +416,42 @@ namespace Hmu_HW5103 {
   model BuildingCircuitPumpOutputDhw {
     /** pump percentage or auto */
     @values(Values_pumpperc)
-    value: percentp;
+    @minValue(49)
+    @maxValue(100)
+    value: percent2;
   }
 
   /** minutes to wait after mains switch on */
   @inherit(r_3, wi_1)
   @ext(0x33, 0x19)
-  model ResetAntiCyclingTime {
+  model BlockTimeAfterRestart {
+    @minValue(0)
+    @maxValue(120)
     value: minutes2;
   }
 
-  /** noise reduction factor applied when in silent mode */
+  /** maximum compressor speed in noise reduction mode */
   @inherit(r_3, wi_1)
   @ext(0x34, 0x28)
   @Ebus.example("40%", "3108b51a0405ff3428", "0aff021b280028003c0001")
-  model CompNoiseReductionFactor {
-    @minValue(30)
+  model CompNoiseReductionSpeed {
+    @minValue(40)
     @maxValue(60)
-    value: percentp;
+    value: percent2;
   }
 
-  /** cooling technology */
+  /** number of main heat pump starts */
+  @inherit(r_3)
+  @ext(0x34, 0x30)
+  model NoOfSwitchingOps {
+    value: cntstarts2;
+  }
+
+  /** cooling enabled */
   @inherit(r_3, wi_1)
   @ext(0x33, 0x1b)
-  model CoolingTechnology {
-    // none / active cooling
-    value: minutes2;
+  model ActiveCoolingEnabled {
+    value: onoff;
   }
 
   // B509

--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -228,6 +228,8 @@ namespace Hmu_HW5103 {
     value: energy;
   }
 
+  // Settings that can be changed from the indoors controller unit
+
   /** default *r */
   @base(MF, 0x1a, 0x5, 0xff)
   model r_3 {

--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -286,6 +286,7 @@ namespace Hmu_HW5103 {
   model HcAlternativePoint {
     @minValue(-20)
     @maxValue(40)
+    @values(Values_alternative_point)
     temp: temp;
   }
 
@@ -677,5 +678,9 @@ namespace Hmu_HW5103 {
 
   enum Values_pumpperc {
     auto: 49,
+  }
+
+  enum Values_alternative_point {
+    off: -21,
   }
 }

--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -231,6 +231,7 @@ namespace Hmu_HW5103 {
   // Settings that can be changed from the indoors controller unit
 
   /** default *r */
+  @auth("install")
   @base(MF, 0x1a, 0x5, 0xff)
   model r_3 {
     @maxLength(3)
@@ -309,14 +310,14 @@ namespace Hmu_HW5103 {
   /** heating function enabled */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x34)
-  model HcModeActive {
+  model HcEnabled {
     yesno: yesno;
   }
 
   /** domestic hot water function enabled */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x35)
-  model HwcModeActive {
+  model HwcEnabled {
     yesno: yesno;
   }
 
@@ -330,7 +331,7 @@ namespace Hmu_HW5103 {
   /** normal immersion heater activation */
   @inherit(r_3, wi_1)
   @ext(0x33, 0x1e)
-  model ImmersionHeaterMode {
+  model ImmersionHeaterEnabled {
     @values(Values_immersion_heater_applications)
     value: UIN;
   }
@@ -338,7 +339,8 @@ namespace Hmu_HW5103 {
   /** emergency immersion heater activation */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x37)
-  model ImmersionHeaterLimpHomeMode {
+  model EmergencyModeImmersionHeaterEnabled {
+    // also called "limp home mode" and "Notbetrieb"
     @values(Values_immersion_heater_applications)
     value: UIN;
   }
@@ -440,7 +442,7 @@ namespace Hmu_HW5103 {
   /** pump speed for domestic hot water */
   @inherit(r_3, wi_1)
   @ext(0x33, 0x18)
-  model BuildingCircuitPumpOutputDhw {
+  model BuildingCircuitPumpOutputHwc {
     /** pump percentage or auto */
     @values(Values_pumpperc)
     @minValue(49)
@@ -461,7 +463,7 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x34, 0x28)
   @Ebus.example("40%", "3108b51a0405ff3428", "0aff021b280028003c0001")
-  model CompNoiseReductionSpeed {
+  model NoiseReductionLevel {
     @minValue(40)
     @maxValue(60)
     value: percent2;
@@ -470,7 +472,7 @@ namespace Hmu_HW5103 {
   /** number of main heat pump starts */
   @inherit(r_3)
   @ext(0x34, 0x30)
-  model HMUStarts {
+  model HMUSystemStarts {
     value: cntstarts2;
   }
 

--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -256,6 +256,8 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x35, 0x2e)
   model SummerSwitchOffTemp {
+    @minValue(10)
+    @maxValue(90)
     temp: temp;
   }
 
@@ -263,6 +265,8 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x35, 0x2f)
   model HcBivalencePoint {
+    @minValue(-30)
+    @maxValue(20)
     temp: temp;
   }
 
@@ -270,6 +274,8 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x35, 0x30)
   model HwcBivalencePoint {
+    @minValue(-20)
+    @maxValue(20)
     temp: temp;
   }
 
@@ -277,6 +283,8 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x35, 0x31)
   model HcAlternativePoint {
+    @minValue(-20)
+    @maxValue(40)
     temp: temp;
   }
 
@@ -284,6 +292,8 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x35, 0x32)
   model MaxFlowTemp {
+    @minValue(15)
+    @maxValue(90)
     temp: temp;
   }
 
@@ -291,17 +301,19 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x35, 0x33)
   model MinFlowTemp {
+    @minValue(15)
+    @maxValue(90)
     temp: temp;
   }
 
-  /** central heating activation */
+  /** heating function enabled */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x34)
   model HcModeActive {
     yesno: yesno;
   }
 
-  /** domestic hot water activation */
+  /** domestic hot water function enabled */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x35)
   model HwcModeActive {
@@ -312,27 +324,31 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x35, 0x39)
   model HwcChargeHysteresis {
-    calibration: calibration;
+    value: hysteresis;
   }
 
-  /** immersion heater activation */
+  /** normal immersion heater activation */
   @inherit(r_3, wi_1)
   @ext(0x33, 0x1e)
   model ImmersionHeaterMode {
-    onoff: onoff;
+    @values(Values_immersion_heater_applications)
+    value: UIN;
   }
 
-  /** limp home mode activation */
+  /** emergency immersion heater activation */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x37)
-  model LimpHomeMode {
-    //onoff: onoff;
+  model ImmersionHeaterLimpHomeMode {
+    @values(Values_immersion_heater_applications)
+    value: UIN;
   }
 
   /** cooling target flow temperature */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x2b)
-  model CoolTargetFlow {
+  model CoolTargetFlowTemp {
+    @minValue(7)
+    @maxValue(24)
     temp: temp;
   }
 
@@ -340,6 +356,8 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x34, 0x1e)
   model CompStartHeatingFrom {
+    @minValue(-999)
+    @maxValue(9)
     value: integral;
   }
 
@@ -347,6 +365,8 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x34, 0x21)
   model CompStartCoolingFrom {
+    @minValue(0)
+    @maxValue(999)
     value: integral;
   }
 
@@ -354,21 +374,28 @@ namespace Hmu_HW5103 {
   @inherit(r_3, wi_1)
   @ext(0x34, 0x43)
   model CompHysteresisHeating {
-    value: integral;
+    @minValue(3)
+    @maxValue(15)
+    value: hysteresis;
   }
 
   /** hysteresis for cooling */
   @inherit(r_3, wi_1)
   @ext(0x35, 0x3f)
   model CompHysteresisCooling {
-    value: integral;
+    @minValue(3)
+    @maxValue(15)
+    value: hysteresis;
   }
 
   /** maximum allowed differential pressure */
   @inherit(r_3, wi_1)
   @ext(0x34, 0x1f)
   model MaxRemainingDeltaP {
-    value: integral;
+    @minValue(200)
+    @maxValue(900)
+    @step(10)
+    value: pressm2;
   }
 
   /** domestic hot water charging mode */
@@ -443,7 +470,7 @@ namespace Hmu_HW5103 {
   /** number of main heat pump starts */
   @inherit(r_3)
   @ext(0x34, 0x30)
-  model NoOfSwitchingOps {
+  model HMUStarts {
     value: cntstarts2;
   }
 
@@ -637,6 +664,13 @@ namespace Hmu_HW5103 {
     eco: 0,
     normal: 1,
     balance: 2,
+  }
+
+  enum Values_immersion_heater_applications {
+    off: 0,
+    heating: 1,
+    dhw: 2,
+    both: 3,
   }
 
   enum Values_pumpperc {

--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -420,6 +420,16 @@ namespace Hmu_HW5103 {
     value: minutes2;
   }
 
+  /** noise reduction factor applied when in silent mode */
+  @inherit(r_3, wi_1)
+  @ext(0x34, 0x28)
+  @Ebus.example("40%", "3108b51a0405ff3428", "0aff021b280028003c0001")
+  model CompNoiseReductionFactor {
+    @minValue(30)
+    @maxValue(60)
+    value: percentp;
+  }
+
   /** cooling technology */
   @inherit(r_3, wi_1)
   @ext(0x33, 0x1b)

--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -228,6 +228,204 @@ namespace Hmu_HW5103 {
     value: energy;
   }
 
+  /** default *r */
+  @base(MF, 0x1a, 0x5, 0xff)
+  model r_3 {
+    @maxLength(3)
+    ign: IGN;
+  }
+
+  /** default *w */
+  @write
+  @auth("install")
+  @base(MF, 0x1a, 0x6, 0xff)
+  model wi_1 {
+  }
+
+  /** heat curve 0.1 to 4.0 */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x2d)
+  model HeatCurve {
+    @divisor(10)
+    bcd: BCD;
+  }
+
+  /** summer switch-off temperature */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x2e)
+  model SummerSwitchOffTemp {
+    temp: temp;
+  }
+
+  /** bivalence point central heating */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x2f)
+  model HcBivalencePoint {
+    temp: temp;
+  }
+
+  /** bivalence point domestic hot water */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x30)
+  model HwcBivalencePoint {
+    temp: temp;
+  }
+
+  /** alternative point central heating */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x31)
+  model HcAlternativePoint {
+    temp: temp;
+  }
+
+  /** maximum allowed flow temperature */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x32)
+  model MaxFlowTemp {
+    temp: temp;
+  }
+
+  /** minimum allowed flow temperature */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x33)
+  model MinFlowTemp {
+    temp: temp;
+  }
+
+  /** central heating activation */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x34)
+  model HcModeActive {
+    yesno: yesno;
+  }
+
+  /** domestic hot water activation */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x35)
+  model HwcModeActive {
+    yesno: yesno;
+  }
+
+  /** hysteresis for cylinder charging */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x39)
+  model HwcChargeHysteresis {
+    calibration: calibration;
+  }
+
+  /** immersion heater activation */
+  @inherit(r_3, wi_1)
+  @ext(0x33, 0x1e)
+  model ImmersionHeaterMode {
+    onoff: onoff;
+  }
+
+  /** limp home mode activation */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x37)
+  model LimpHomeMode {
+    //onoff: onoff;
+  }
+
+  /** cooling target flow temperature */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x2b)
+  model CoolTargetFlow {
+    temp: temp;
+  }
+
+  /** start heating at energy integral value */
+  @inherit(r_3, wi_1)
+  @ext(0x34, 0x1e)
+  model CompStartHeatingFrom {
+    value: integral;
+  }
+
+  /** start cooling at energy integral value */
+  @inherit(r_3, wi_1)
+  @ext(0x34, 0x21)
+  model CompStartCoolingFrom {
+    value: integral;
+  }
+
+  /** hysteresis for heating */
+  @inherit(r_3, wi_1)
+  @ext(0x34, 0x43)
+  model CompHysteresisHeating {
+    value: integral;
+  }
+
+  /** hysteresis for cooling */
+  @inherit(r_3, wi_1)
+  @ext(0x35, 0x3f)
+  model CompHysteresisCooling {
+    value: integral;
+  }
+
+  /** maximum allowed differential pressure */
+  @inherit(r_3, wi_1)
+  @ext(0x34, 0x1f)
+  model MaxRemainingDeltaP {
+    value: integral;
+  }
+
+  /** domestic hot water charging mode */
+  @inherit(r_3, wi_1)
+  @ext(0x34, 0x44)
+  model HwcMode {
+    @values(Values_Domestic_hot_water_mod__eco_normal_balance_)
+    uch: UCH;
+  }
+
+  /** maximum anti-cycling time */
+  @inherit(r_3, wi_1)
+  @ext(0x34, 0x2d)
+  model MaxAntiCyclingTime {
+    value: integral;
+  }
+
+  /** pump speed for heating */
+  @inherit(r_3, wi_1)
+  @ext(0x33, 0x16)
+  model BuildingCircuitPumpOutputHeating {
+    /** pump percentage or auto */
+    @values(Values_pumpperc)
+    value: percentp;
+  }
+
+  /** pump speed for cooling */
+  @inherit(r_3, wi_1)
+  @ext(0x33, 0x17)
+  model BuildingCircuitPumpOutputCooling {
+    /** pump percentage or auto */
+    @values(Values_pumpperc)
+    value: percentp;
+  }
+
+  /** pump speed for domestic hot water */
+  @inherit(r_3, wi_1)
+  @ext(0x33, 0x18)
+  model BuildingCircuitPumpOutputDhw {
+    /** pump percentage or auto */
+    @values(Values_pumpperc)
+    value: percentp;
+  }
+
+  /** minutes to wait after mains switch on */
+  @inherit(r_3, wi_1)
+  @ext(0x33, 0x19)
+  model ResetAntiCyclingTime {
+    value: minutes2;
+  }
+
+  /** cooling technology */
+  @inherit(r_3, wi_1)
+  @ext(0x33, 0x1b)
+  model CoolingTechnology {
+    // none / active cooling
+    value: minutes2;
+  }
+
   // B509
   /** default *r */
   @base(MF, 0x9, 0x54, 0x2, 0)
@@ -405,5 +603,15 @@ namespace Hmu_HW5103 {
   union _includes {
     Hcmode_inc,
     Errors_inc,
+  }
+
+  enum Values_Domestic_hot_water_mod__eco_normal_balance_ {
+    eco: 0,
+    normal: 1,
+    balance: 2,
+  }
+
+  enum Values_pumpperc {
+    auto: 49,
   }
 }

--- a/src/vaillant/_templates.tsp
+++ b/src/vaillant/_templates.tsp
@@ -66,9 +66,9 @@ scalar twopointanalog extends UCH;
 @minValue(0) @maxValue(100) @step(0.5)
 scalar percentv extends EXP;
 
-/** pump percentage */
+/** percentage */
 @unit("%")
-scalar percentp extends UIN;
+scalar percent2 extends UIN;
 
 /** date */
 scalar date extends HDA3;

--- a/src/vaillant/_templates.tsp
+++ b/src/vaillant/_templates.tsp
@@ -184,6 +184,10 @@ scalar calibrations extends SCH;
 @minValue(-50) @maxValue(50) @step(0.5)
 scalar calibrationv extends EXP;
 
+@unit("K")
+@divisor(16)
+scalar hysteresis extends UIN;
+
 @unit("°min")
 scalar integral extends SIN;
 

--- a/src/vaillant/_templates.tsp
+++ b/src/vaillant/_templates.tsp
@@ -66,6 +66,10 @@ scalar twopointanalog extends UCH;
 @minValue(0) @maxValue(100) @step(0.5)
 scalar percentv extends EXP;
 
+/** pump percentage */
+@unit("%")
+scalar percentp extends UIN;
+
 /** date */
 scalar date extends HDA3;
 


### PR DESCRIPTION
These are most of the settings that can be changed from the VWZ AI install menu on an Arotherm Plus.
Many of these had already been available in the 08.hmu.tsp config, but definitely not all.
Most have been available in the @jonesPD csv repository.

**This PR contains read and write rules for each of the settings.**

- Ready for review, not ready for merging yet.
- I've left out a few values that I do not have (but are mentioned by the manual), I will be taking another look at these.
- Is "max allowed current" too dangerous to expose for writing remotely? Left it out now.

@john30 @burmistrzak @chrizzzp Please do have a look. If some of this is already work in progress, please let me know where to find it.

Should fix at least #475 and #586, #555, #535.
