### PR TITLE
vaillant: add Status07 (display/operating mode) to 08.hmu.HW5103

### DIFF
--- a/src/vaillant/08.hmu.HW5103.tsp
+++ b/src/vaillant/08.hmu.HW5103.tsp
@@ -32,6 +32,125 @@ namespace Hmu_HW5103 {
     cycles: cntstarts;
   }
 
+  /** HMU display state: compressor power, environmental yield and heater main/backup operating mode */
+  @inherit(r_1)
+  @ext(0x7)
+  model Status07 {
+    /** compressor power */
+    @unit("%")
+    power: UCH;
+
+    /** daily environmental energy yield */
+    @divisor(10)
+    dailyenvyield: energy;
+
+    /** heater main enabled */
+    @values(Values_onoff)
+    display_b0_heaterenabled: BI0;
+
+    /** reserved bit 1 */
+    @values(Values_onoff)
+    display_b1: BI1;
+
+    /** backup heater active */
+    @values(Values_onoff)
+    display_b2_backupheater: BI2;
+
+    /** reserved bit 3 */
+    @values(Values_onoff)
+    display_b3: BI3;
+
+    /** reserved bit 4 */
+    @values(Values_onoff)
+    display_b4: BI4;
+
+    /** noise reduction active */
+    @values(Values_onoff)
+    display_b5_noisereduction: BI5;
+
+    /** DHW eco mode */
+    @values(Values_onoff)
+    display_b6_dhwecomode: BI6;
+
+    /** reserved bit 7 */
+    @values(Values_onoff)
+    display_b7: BI7;
+
+    // heater main operating mode (bit field; bit semantics per @hanjo in #614,
+    // confirmed against a 72 h bus capture: only standby/heating/warmwater seen here)
+
+    /** reserved bit 0 */
+    @values(Values_onoff)
+    heatermain_b0: BI0;
+
+    /** error active (Komfortsicherung) */
+    @values(Values_onoff)
+    heatermain_b1_error: BI1;
+
+    /** reserved bit 2 */
+    @values(Values_onoff)
+    heatermain_b2: BI2;
+
+    /** heating active */
+    @values(Values_onoff)
+    heatermain_b3_heating: BI3;
+
+    /** cooling active */
+    @values(Values_onoff)
+    heatermain_b4_cooling: BI4;
+
+    /** pressure loss */
+    @values(Values_onoff)
+    heatermain_b5_pressureloss: BI5;
+
+    /** reserved bit 6 */
+    @values(Values_onoff)
+    heatermain_b6: BI6;
+
+    /** hot water active */
+    @values(Values_onoff)
+    heatermain_b7_warmwater: BI7;
+
+    /** system pressure */
+    @unit("bar")
+    @divisor(30)
+    DisplayPressure: UCH;
+
+    // backup heater operating mode (same bit field as the main heater)
+
+    /** reserved bit 0 */
+    @values(Values_onoff)
+    heaterbackup_b0: BI0;
+
+    /** error active (Komfortsicherung) */
+    @values(Values_onoff)
+    heaterbackup_b1_error: BI1;
+
+    /** reserved bit 2 */
+    @values(Values_onoff)
+    heaterbackup_b2: BI2;
+
+    /** heating active */
+    @values(Values_onoff)
+    heaterbackup_b3_heating: BI3;
+
+    /** cooling active */
+    @values(Values_onoff)
+    heaterbackup_b4_cooling: BI4;
+
+    /** pressure loss */
+    @values(Values_onoff)
+    heaterbackup_b5_pressureloss: BI5;
+
+    /** reserved bit 6 */
+    @values(Values_onoff)
+    heaterbackup_b6: BI6;
+
+    /** hot water active */
+    @values(Values_onoff)
+    heaterbackup_b7_warmwater: BI7;
+  }
+
   /** default *r */
   @base(MF, 0x1a, 0x5, 0xff, 0x32)
   model r_2 {


### PR DESCRIPTION
## Summary

Adds `Status07` (`b511 07`) to `08.hmu.HW5103.tsp`, restoring the heat-pump operating mode ("Betriebsart") for HW=5103 owners. **Closes #609.**

The legacy generic `08.hmu.csv` exposed the operating mode (heating / cooling / hot water / error) as field 4 of the old "State" message on `b511 07`. The HW=5103 variant file never carried `b511 07`, so that value disappeared for HW=5103 users.

As diagnosed in #609, there is no working substitute among the other `b511` messages: on this hardware **`Status02` (`b511 02`) and `Status` (`b511 03`) return an empty body to an active read**, which is exactly the `ERR: invalid position in decode` the reporter hit. Reproduced on my own HW=5103:

```
hmu Status02 =  (ERR: invalid position for 3108b5110102 / 00)
hmu Status   =  (ERR: invalid position for 3108b5110103 / 00)
```

## What it decodes

`Status07` is a 7-byte poll message:

| field | type | meaning |
|---|---|---|
| `power` | UCH % | compressor power |
| `dailyenvyield` | UIN /10 kWh | daily environmental energy yield |
| `display_b0..b7` | bit flags | b0=heater enabled, b2=backup heater active, b5=noise reduction, b6=DHW eco mode (per @chrizzzp in #598); b1/b3/b4/b7 reserved |
| `heatermain_b0..b7` | bit flags | **heater main operating mode** (see below) |
| `DisplayPressure` | UCH /30 bar | system pressure |
| `heaterbackup_b0..b7` | bit flags | backup heater operating mode (same encoding) |

## Operating-mode byte is a bit field

Thanks to @hanjo (the #609 reporter, who uses this value in production to drive his underfloor heating and to detect "Komfortsicherung"), the mode byte is modelled as a **bit field** rather than an enum:

| bit | meaning |
|---|---|
| b1 | error active (Komfortsicherung) |
| b3 | heating |
| b4 | cooling |
| b5 | pressure loss |
| b7 | hot water |
| b0 / b2 / b6 | reserved (not yet observed) |

This was cross-checked against a **72 h bus capture** on a `HW=5103;SW=0902` unit, where the main mode byte only ever took `0x00` (standby), `0x08` (heating) and `0x80` (hot water) — clean single bits, exactly matching the model. cooling / error / pressure-loss did not occur in that window but are confirmed by @hanjo from production use.

## Verification

Live read on a `HW=5103;SW=0902` unit (standby at the time):

```
# ebusctl r -c hmu Status07
0;7.8;off;off;off;off;off;off;off;on;...;1.20;...
```

Build:
- `tsp compile --emit @ebusd/ebus-typespec --warn-as-error` exits 0
- `tsp format` reports the file unchanged

## Notes

- Scoped to the heat-pump HMU file only — deliberately **not** added to the shared `hcmode_inc.tsp`, since the compressor-power / environmental-yield / heat-pump-mode fields would be meaningless on the BAI / solsy / vr630 devices that also include it.
- Separate from #599 (RunDataFlowTemp/ReturnTemp), which touches the same file but is an unrelated concern.

## Update: bit semantics validated against 6+ years of data

@hanjo evaluated his historical recordings of the main mode byte (collected since Dec 2019):

| value | occurrences | bits set |
|---:|---:|---|
| 0 | 7447 | standby |
| 2 | 196 | error |
| 8 | 8964 | heating |
| 16 | 1888 | cooling |
| 32 | 23 | pressure loss |
| 34 | 2 | error + pressure loss |
| 40 | 12 | heating + pressure loss |
| 48 | 33 | cooling + pressure loss |
| 128 | 9798 | hot water |
| 160 | 37 | hot water + pressure loss |

This confirms the model end-to-end: the reserved bits (b0/b2/b6) were **never** observed, and pressure loss (b5) is the only bit that co-occurs with a mode — which the per-bit representation handles naturally.

### Note on bit 0 vs. the legacy `08.hmu.csv`

The generic `08.hmu.csv` `State` field decodes this byte as `1=ready;9=heating;17=cooling;129=heating_water` — i.e. bit 0 ("ready") is set on every active state. On HW=5103 bit 0 is **never** set: both a raw 72 h capture and @hanjo's long-term data only ever show `0/8/16/128/...`. So bit 0 is left `reserved` here — the HW=5103 firmware reports the mode without the legacy "ready" flag, which is part of why this hardware needs its own decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


