### PR TITLE
Chane units to Homeassistant units

### DIFF
--- a/src/vaillant/_templates.tsp
+++ b/src/vaillant/_templates.tsp
@@ -33,15 +33,15 @@ scalar press extends FLT;
 @minValue(0) @maxValue(70) @step(0.5)
 scalar pressv extends EXP;
 
-@unit("l/h")
+@unit("L/h")
 @maxValue(20)
 scalar flowrate extends UIN;
 
-@unit("l/min")
+@unit("L/min")
 @divisor(100)
 scalar flowrate100 extends UIN;
 
-@unit("m3/h")
+@unit("m³/h")
 @maxValue(400)
 scalar airflowrate extends UIN;
 


### PR DESCRIPTION
see https://github.com/home-assistant/core/blob/master/homeassistant/const.py#L649C30-L649C34 for valid units

Homeassistant is showing in log
Error 'The unit of measurement `m3/h` is not valid together with device class `volume_flow_rate`' when processing MQTT discovery message topic: 'homeassistant/sensor/micro-ebusd-lueftung_recov_SupplyFlowActual_value/config', message: '{'device': {'via_device': 'micro-ebusd-lueftung', 'suggested_area': 'Heating', 'identifiers': 'micro-ebusd-lueftung_recov', 'name': 'micro-ebusd-lueftung recov', 'configuration_url': 'http://192.168.178.161/#/msg?q=recov', 'manufacturer': 'ebusd.eu'}, 'unique_id': 'micro-ebusd-lueftung_recov_SupplyFlowActual_value', 'min': 0, 'unit_of_measurement': 'm3/h', 'state_topic': 'micro-ebusd-lueftung/recov/SupplyFlowActual', 'name': 'SupplyFlowActual', 'step': 1, 'value_template': '{{value_json["value"]}}', 'state_class': 'measurement', 'device_class': 'volume_flow_rate', 'max': 65534}'
Error 'The unit of measurement `l/h` is not valid together with device class `volume_flow_rate`' when processing MQTT discovery message topic: 'homeassistant/sensor/micro-ebusd-heizung_hmu_BuildingCircuitFlow_value/config', message: '{'device': {'via_device': 'micro-ebusd-heizung', 'suggested_area': 'Heating', 'identifiers': 'micro-ebusd-heizung_hmu', 'name': 'micro-ebusd-heizung hmu', 'configuration_url': 'http://192.168.178.162/#/msg?q=hmu', 'manufacturer': 'ebusd.eu'}, 'unique_id': 'micro-ebusd-heizung_hmu_BuildingCircuitFlow_value', 'min': 0, 'unit_of_measurement': 'l/h', 'state_topic': 'micro-ebusd-heizung/hmu/BuildingCircuitFlow', 'name': 'BuildingCircuitFlow', 'step': 1, 'value_template': '{{value_json["value"]}}', 'state_class': 'measurement', 'device_class': 'volume_flow_rate', 'max': 65534}'

This should fix auto discovery of those values.
