### PR TITLE
Add 15.b7s00.tsp for Vaillant Mipro R (B7S00) - OEM alias of VRC 700

### DIFF
--- a/src/vaillant/15.b7s00.tsp
+++ b/src/vaillant/15.b7s00.tsp
@@ -1,0 +1,10 @@
+import "@ebusd/ebus-typespec";
+import "./_templates.tsp";
+import "./15.700.tsp";  // réutilise toutes les définitions du VRC 700
+
+using Vaillant;
+
+/** Vaillant Mipro R (B7S00) - alias of VRC 700 */
+@zz(0x15)
+namespace _B7S00 extends _700 {}
+


### PR DESCRIPTION
## Description

Adds a new TypeSpec file for the **Vaillant Mipro R (B7S00)**, which is an OEM variant of the VRC 700 controller.

The B7S00 returns the following eBUS scan result:
```
scan 15: ;Vaillant;B7S00;SW0422;HW5503
```

Since the B7S00 is functionally identical to the VRC 700 (`70000`), this file simply extends `_700` namespace without any modifications.

## Motivation

Without this file, ebusd reports:
```
unable to load scan config 15: no file from vaillant with prefix 15 matches ID "b7s00"
```

This prevents loading of the 467 messages defined in `15.700.tsp` (including `WaterPressure`, heating schedules, etc.) for users with a Mipro R unit.