### PR TITLE
Vaillant VR_71: add keepValveOperable (4) to Mc{1,2,3}Operation status enum

### DIFF
--- a/src/vaillant/26.vr_71.tsp
+++ b/src/vaillant/26.vr_71.tsp
@@ -144,13 +144,23 @@ namespace Vr_71 {
   }
 
   /**
-   * Mixer-circuit operation status. Value 4 is written by the controller in a
-   * short daily burst (~5 min) on otherwise-off circuits — a "keep valve
-   * operable" maintenance run (anti-seize). See issue #620.
+   * Mixer-circuit operation status. See issue #620.
+   *
+   * Value 4 is written by the controller in a short daily burst (~5 min) on
+   * otherwise-off circuits — a "keep valve operable" maintenance run
+   * (anti-seize).
+   *
+   * Value 2 occurs on cooling-capable systems while the circuit is cooling
+   * (reported for a VR 71 + VRC 700 driving aroVAIR convectors: flow target
+   * 10 °C at 2 versus 42.5-44 °C at 1). On those systems 1 therefore means
+   * "heating" rather than a generic "on"; the label is kept as `on` because
+   * this field used the shared `onoff` type before, and renaming it would
+   * change the reported state for every existing installation.
    */
   enum Values_McStatus {
     off: 0,
     on: 1,
+    cooling: 2,
     keepValveOperable: 4,
   }
 

--- a/src/vaillant/26.vr_71.tsp
+++ b/src/vaillant/26.vr_71.tsp
@@ -67,7 +67,9 @@ namespace Vr_71 {
   @inherit(w_1)
   @ext(0x2, 0)
   model Mc1Operation {
-    status: onoff;
+    @values(Values_McStatus)
+    status: UCH;
+
     flowtempdesired: temp1;
 
     @in
@@ -80,7 +82,9 @@ namespace Vr_71 {
   @inherit(w_1)
   @ext(0x2, 1)
   model Mc2Operation {
-    status: onoff;
+    @values(Values_McStatus)
+    status: UCH;
+
     flowtempdesired: temp1;
 
     @in
@@ -93,7 +97,9 @@ namespace Vr_71 {
   @inherit(w_1)
   @ext(0x2, 0x2)
   model Mc3Operation {
-    status: onoff;
+    @values(Values_McStatus)
+    status: UCH;
+
     flowtempdesired: temp1;
 
     @in
@@ -135,6 +141,17 @@ namespace Vr_71 {
   enum Values_ActorState {
     off: 0,
     on: 20,
+  }
+
+  /**
+   * Mixer-circuit operation status. Value 4 is written by the controller in a
+   * short daily burst (~5 min) on otherwise-off circuits — a "keep valve
+   * operable" maintenance run (anti-seize). See issue #620.
+   */
+  enum Values_McStatus {
+    off: 0,
+    on: 1,
+    keepValveOperable: 4,
   }
 
   /** included parts */


### PR DESCRIPTION
## What

`Mc{1,2,3}Operation.status` (`b523 0200/0201/0202`) is currently typed `onoff` (`0=off;1=on`). On real installs the controller also writes `status = 4`, which the shared `onoff` type doesn't cover, so ebusd passes the raw value through and Home Assistant's enum sensor rejects every such update:

```
Ignoring invalid option received on topic 'ebusd/vr_71/Mc1Operation', got '4', allowed: off, on
```

This adds a dedicated `Values_McStatus` enum (`off=0, on=1, keepValveOperable=4`) for the three `status` fields and leaves `pump` on `onoff`.

## Why `4 = keepValveOperable`

Per the discussion in #620 across three independent VR_71 installs: `status=4` appears in a short daily burst (~5 min) on otherwise-off circuits — a valve anti-seize / "keep valve operable" maintenance run. Observed `status` values are only `0` and `4`; `1` (on) was not seen. Name suggested by @Hoppur.

## Verification

- `tsp compile --warn-as-error` passes.
- Emitted CSV (Mc1/2/3): `status,,UCH,0=off;1=on;4=keepValveOperable`.
- `tsp format` clean; `pump` unchanged (`onoff`).

Closes #620
