### PR TITLE
Corrected units

### DIFF
--- a/src/encon/3c..excellent.tsp
+++ b/src/encon/3c..excellent.tsp
@@ -100,10 +100,19 @@ namespace Excellent {
   @inherit(r_1)
   @ext(0x22)
   model TotalFilterDays {
+    @unit("d")
     days: days;
+
+    @unit("d")
     min: days;
+
+    @unit("d")
     max: days;
+
+    @unit("d")
     step: days;
+
+    @unit("d")
     default: days;
   }
 
@@ -133,7 +142,7 @@ namespace Excellent {
   @inherit(r_1)
   @ext(0x25)
   model TotalFlow {
-    volume: volume;
+    total: volume;
     min: volume;
     max: volume;
     step: volume;


### PR DESCRIPTION
Error 'The unit of measurement `days` is not valid together with device class `duration`' when processing MQTT discovery message topic: 'homeassistant/sensor/eas_excellent_TotalFilterDays_days/config', message: '{'unit_of_measurement': 'days', 'device_class': 'duration', 'unique_id': 'eas_excellent_TotalFilterDays_days', 'device': {'via_device': 'eas', 'configuration_url': 'http://192.168.101.52/#/msg?q=excellent', 'manufacturer': 'ebusd.eu', 'suggested_area': 'Heating', 'identifiers': 'eas_excellent', 'name': 'eas excellent'}, 'value_template': '{{value_json["days"]}}', 'max': 65534, 'min': 0, 'state_topic': 'eas/excellent/TotalFilterDays', 'name': 'TotalFilterDays days', 'step': 1}'

Entity sensor.eas_excellent_totalflow_volume (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using state class 'measurement' which is impossible considering device class ('volume') it is using; expected None or one of 'total_increasing', 'total'; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22