### PR TITLE
vaillant: add SystemDemand for CTLV2

### DIFF
--- a/src/vaillant/15.ctlv2.tsp
+++ b/src/vaillant/15.ctlv2.tsp
@@ -71,6 +71,21 @@ namespace _720 {
     ign: IGN;
   }
 
+  enum Values_SystemDemand {
+    off: 0,
+    heating: 1,
+    cooling: 2,
+    hot_water: 3,
+  }
+
+  /** current system demand - cooling=2 is assumed */
+  @inherit(r_1)
+  @ext(0x48, 0)
+  model SystemDemand {
+    @values(Values_SystemDemand)
+    value: UIN;
+  }
+
   /** default *ri for user level "install" */
   @auth("install")
   @base(MF, 0x24, 0x2, 0, 0, 0)


### PR DESCRIPTION
Adds decoding for B524 register 0x48 as SystemDemand on CTLV2/BASV3. Observed values on real hardware: 0=off, 1=heating, 3=hot_water. 2=cooling is currently assumed. Related to #570.