### PR TITLE
fix(encon): rename BypassCurrent to BypassPosition

### DIFF
--- a/src/encon/3c..excellent.tsp
+++ b/src/encon/3c..excellent.tsp
@@ -249,10 +249,10 @@ namespace Excellent {
     value: UIR;
   }
 
-  /** Bypass current */
+  /** Current bypass position */
   @inherit(r_2)
   @ext(0xd)
-  model BypassCurrent {
+  model BypassPosition {
     value: UIR;
   }
 


### PR DESCRIPTION
### Description

Rename `BypassCurrent` to `BypassPosition` in the Brink Excellent configuration.

The value represents the current bypass position, not electrical current.

The existing name `BypassCurrent` causes Home Assistant MQTT discovery to interpret the message as an electrical current measurement and assign:

`device_class: current`

Renaming the message to `BypassPosition` avoids this incorrect device class while keeping the register and data type unchanged.

### Changes

* Rename `BypassCurrent` to `BypassPosition`
* Change description from `Bypass current` to `Current bypass position`
* No change to `@ext(0xd)` or the `UIR` data type

### Testing

The TypeSpec configuration compiles successfully locally and generates the expected ebusd definition:

`BypassPosition,Current bypass position,...,UIR`
