### PR TITLE
vaillant: fix error/service history date+time types to BCD

### DIFF
--- a/src/vaillant/_templates.tsp
+++ b/src/vaillant/_templates.tsp
@@ -69,6 +69,10 @@ scalar percentv extends EXP;
 /** date */
 scalar date extends HDA3;
 
+// BCD variant of the above, as used in the error/service history records
+/** date */
+scalar date2 extends BDA3;
+
 /** weekday */
 scalar day extends BDY;
 
@@ -93,6 +97,10 @@ scalar time extends VTI;
 
 /** time */
 scalar time2 extends VTM;
+
+// BCD variant of the above, as used in the error/service history records
+/** time */
+scalar time3 extends BTM;
 
 /** minutes */
 @unit("min")
@@ -341,8 +349,8 @@ model errors {
 
 model errorhistory {
   status: status;
-  time: time2;
-  date: date;
+  time: time3;
+  date: date2;
   error: error;
 }
 


### PR DESCRIPTION
Follow-up to the discussion in #660 / #638.

The Vaillant error history record is sent in **BCD**, but the shared `errorhistory` model in `src/vaillant/_templates.tsp` uses the hex variants `VTM` (via `time2`) and `HDA3` (via `date`). That makes the record undecodable on some entries — and, on others, silently wrong.

## Evidence

Live telegrams, two different device families on the same bus.

`MF=Vaillant;ID=HMU00;SW=0902;HW=5103` (`b503 0101`, `NN=03`, index byte appended):

```
>3108b5030301010052<000a0200091411241600ff001b>00   index 0
>3108b5030301010153<000a0243121609241600ff0071>00   index 1
>3108b5030301010250<000a0247071209241600ff00f1>00   index 2
>3108b5030301010351<000a0206122604241600000047>00   index 3
>3108b503030101095b<000a010000000000ffff000092>00   index 9 (empty slot)
```

`MF=Vaillant;ID=CTLV2;SW=0514;HW=1104`:

```
>3115b503030101004c<0008024513081124b7048e>00       index 0
>3115b503030101014d<000800ffffffffffffff64>00       index 1 (empty slot)
```

Checked with `ebusctl decode`:

| field | current type | bytes | result | proposed | result |
|---|---|---|---|---|---|
| time | `VTM` | `4312` | `ERR: argument value out of valid range` | `BTM` | `12:43` |
| time | `VTM` | `4513` | `ERR: argument value out of valid range` | `BTM` | `13:45` |
| date | `HDA:3` | `141124` | `ERR: argument value out of valid range` | `BDA:3` | `14.11.2024` |
| date | `HDA:3` | `160924` | `22.09.2036` — no error, just wrong | `BDA:3` | `16.09.2024` |

The `160924` row is the reason I think this is worth fixing rather than working around: `HDA:3` does not fail there, it returns a plausible-looking incorrect date.

## Why new scalars instead of changing `date` / `time2`

Both existing scalars are *correct* where else they are used — verified live on the same CTLV2:

- `Date` (`value: date`, `HDA3`) reads `05.09.2026` — correct.
- `time2` (`VTM`) is otherwise only used by `EcoModeUntil` in `15.vai.tsp`.

So the hex types are right for the plain registers and wrong only inside the history record. This adds `date2` (`BDA3`) and `time3` (`BTM`) alongside them and uses those in `errorhistory`.

## Scope of the emitted change

`tsp compile --warn-as-error` passes. Diffing the emitted CSV tree before/after, the delta is exactly the `Errorhistory` and `Servicehistory` lines in 47 files — the two type columns, nothing else:

```
-r,,,Errorhistory,...,time,,VTM,,,time,date,,HDA:3,,,date,error,,UIN,,,error number
+r,,,Errorhistory,...,time,,BTM,,,time,date,,BDA:3,,,date,error,,UIN,,,error number
```

**One caveat I want to be explicit about:** `Servicehistory` (`service_inc.tsp`, `b503 0102`) reuses the same `errorhistory` model, so it changes too. Neither of my devices exposes that message, so I have no measurement for it — I assumed the record layout is the same as for `b503 0101`. If you'd rather not touch it on an assumption, I'm happy to give service history its own model and leave it on the hex types.

Related: this is the register that #660 proposes to drop for HW5103 on the grounds that it is not implemented there. As noted in that thread, the `00` reply seen in #638 comes from a request without the mandatory `index` master byte (`NN=02` instead of `NN=03`), which is also what ebusd's own auto-poll sends for a message with an `m` field. With the index supplied the register answers, as above.
